### PR TITLE
Add Google Analytics (G-KKL15STH52) to all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -67,17 +67,15 @@
   </style>
 
   <!-- @@analytics:start -->
-  <!-- Google Analytics 4
-       Replace G-XXXXXXXXXX with your real Measurement ID from:
-       analytics.google.com → Admin → Data Streams → your stream → Measurement ID -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KKL15STH52"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-XXXXXXXXXX');
+    gtag('config', 'G-KKL15STH52');
   </script>
-  <!-- @@analytics:end -->
+<!-- @@analytics:end -->
 
   <!-- @@theme-flash:start -->
   <!-- Apply saved theme before page renders to prevent flash -->
@@ -88,7 +86,7 @@
       }
     }());
   </script>
-  <!-- @@theme-flash:end -->
+<!-- @@theme-flash:end -->
 </head>
 <body>
 
@@ -117,7 +115,7 @@
       </div>
     </div>
   </nav>
-  <!-- @@nav:end -->
+<!-- @@nav:end -->
 
   <main id="main-content" tabindex="-1">
     <div class="not-found">
@@ -157,18 +155,18 @@
       </div>
     </div>
   </footer>
-  <!-- @@footer:end -->
+<!-- @@footer:end -->
 
   <!-- @@back-to-top:start -->
   <button class="back-to-top" id="backToTop" aria-label="Back to top">
     <svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="18 15 12 9 6 15"/></svg>
   </button>
-  <!-- @@back-to-top:end -->
+<!-- @@back-to-top:end -->
 
   <!-- @@scripts-common:start -->
   <script src="js/theme.js" defer></script>
   <script src="js/main.js" defer></script>
-  <!-- @@scripts-common:end -->
+<!-- @@scripts-common:end -->
 
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -206,17 +206,15 @@
   </style>
 
   <!-- @@analytics:start -->
-  <!-- Google Analytics 4
-       Replace G-XXXXXXXXXX with your real Measurement ID from:
-       analytics.google.com → Admin → Data Streams → your stream → Measurement ID -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KKL15STH52"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-XXXXXXXXXX');
+    gtag('config', 'G-KKL15STH52');
   </script>
-  <!-- @@analytics:end -->
+<!-- @@analytics:end -->
 
   <!-- @@theme-flash:start -->
   <!-- Apply saved theme before page renders to prevent flash -->
@@ -227,7 +225,7 @@
       }
     }());
   </script>
-  <!-- @@theme-flash:end -->
+<!-- @@theme-flash:end -->
 </head>
 <body>
 
@@ -256,7 +254,7 @@
       </div>
     </div>
   </nav>
-  <!-- @@nav:end -->
+<!-- @@nav:end -->
 
   <main id="main-content" tabindex="-1">
 
@@ -345,18 +343,18 @@
       </div>
     </div>
   </footer>
-  <!-- @@footer:end -->
+<!-- @@footer:end -->
 
   <!-- @@back-to-top:start -->
   <button class="back-to-top" id="backToTop" aria-label="Back to top">
     <svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="18 15 12 9 6 15"/></svg>
   </button>
-  <!-- @@back-to-top:end -->
+<!-- @@back-to-top:end -->
 
   <!-- @@scripts-common:start -->
   <script src="js/theme.js" defer></script>
   <script src="js/main.js" defer></script>
-  <!-- @@scripts-common:end -->
+<!-- @@scripts-common:end -->
   <script>
     document.getElementById('contactForm').addEventListener('submit', function (e) {
       e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -80,17 +80,15 @@
   <link rel="stylesheet" href="css/main.css">
 
   <!-- @@analytics:start -->
-  <!-- Google Analytics 4
-       Replace G-XXXXXXXXXX with your real Measurement ID from:
-       analytics.google.com → Admin → Data Streams → your stream → Measurement ID -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KKL15STH52"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-XXXXXXXXXX');
+    gtag('config', 'G-KKL15STH52');
   </script>
-  <!-- @@analytics:end -->
+<!-- @@analytics:end -->
 
   <!-- @@theme-flash:start -->
   <!-- Apply saved theme before page renders to prevent flash -->
@@ -101,7 +99,7 @@
       }
     }());
   </script>
-  <!-- @@theme-flash:end -->
+<!-- @@theme-flash:end -->
 </head>
 <body>
 
@@ -130,7 +128,7 @@
       </div>
     </div>
   </nav>
-  <!-- @@nav:end -->
+<!-- @@nav:end -->
 
   <main id="main-content" tabindex="-1">
 
@@ -475,18 +473,18 @@
       </div>
     </div>
   </footer>
-  <!-- @@footer:end -->
+<!-- @@footer:end -->
 
   <!-- @@back-to-top:start -->
   <button class="back-to-top" id="backToTop" aria-label="Back to top">
     <svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="18 15 12 9 6 15"/></svg>
   </button>
-  <!-- @@back-to-top:end -->
+<!-- @@back-to-top:end -->
 
   <!-- @@scripts-common:start -->
   <script src="js/theme.js" defer></script>
   <script src="js/main.js" defer></script>
-  <!-- @@scripts-common:end -->
+<!-- @@scripts-common:end -->
 
 </body>
 </html>

--- a/project.html
+++ b/project.html
@@ -73,17 +73,15 @@
   <link rel="stylesheet" href="css/connect.css">
 
   <!-- @@analytics:start -->
-  <!-- Google Analytics 4
-       Replace G-XXXXXXXXXX with your real Measurement ID from:
-       analytics.google.com → Admin → Data Streams → your stream → Measurement ID -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KKL15STH52"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-XXXXXXXXXX');
+    gtag('config', 'G-KKL15STH52');
   </script>
-  <!-- @@analytics:end -->
+<!-- @@analytics:end -->
 
   <!-- @@theme-flash:start -->
   <!-- Apply saved theme before page renders to prevent flash -->
@@ -94,7 +92,7 @@
       }
     }());
   </script>
-  <!-- @@theme-flash:end -->
+<!-- @@theme-flash:end -->
 </head>
 <body>
 
@@ -123,7 +121,7 @@
       </div>
     </div>
   </nav>
-  <!-- @@nav:end -->
+<!-- @@nav:end -->
 
   <main id="main-content" tabindex="-1">
 
@@ -503,20 +501,20 @@
       </div>
     </div>
   </footer>
-  <!-- @@footer:end -->
+<!-- @@footer:end -->
 
   <!-- @@back-to-top:start -->
   <button class="back-to-top" id="backToTop" aria-label="Back to top">
     <svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="18 15 12 9 6 15"/></svg>
   </button>
-  <!-- @@back-to-top:end -->
+<!-- @@back-to-top:end -->
 
   <script src="js/project.js" defer></script>
   <script src="js/connect.js" defer></script>
   <!-- @@scripts-common:start -->
   <script src="js/theme.js" defer></script>
   <script src="js/main.js" defer></script>
-  <!-- @@scripts-common:end -->
+<!-- @@scripts-common:end -->
 
 </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -6,6 +6,15 @@
   <title>Resume — Dexter Miller</title>
   <meta name="robots" content="noindex">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KKL15STH52"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-KKL15STH52');
+  </script>
+
   <style>
     @font-face {
       font-family: 'Inter';

--- a/src/partials/analytics.html
+++ b/src/partials/analytics.html
@@ -1,10 +1,8 @@
-  <!-- Google Analytics 4
-       Replace G-XXXXXXXXXX with your real Measurement ID from:
-       analytics.google.com → Admin → Data Streams → your stream → Measurement ID -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KKL15STH52"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-XXXXXXXXXX');
+    gtag('config', 'G-KKL15STH52');
   </script>


### PR DESCRIPTION
## Summary

- Updated `src/partials/analytics.html` with the real GA4 measurement ID (`G-KKL15STH52`)
- Ran `npm run build` to propagate the tag to `index.html`, `project.html`, `contact.html`, and `404.html`
- Manually added the tag to `resume.html` (standalone file, outside the build system)

## Test plan

- [ ] Verify GA4 tag fires on all 5 pages using the Google Tag Assistant Chrome extension or browser network tab (look for requests to `googletagmanager.com`)
- [ ] Confirm data appears in Google Analytics → Real-time report after visiting the site

https://claude.ai/code/session_01VASEMQysNtc17XHFvggpQr