### PR TITLE
Fix resume print layout and rename button to Download Resume

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -352,7 +352,12 @@
 
     /* ── Print ── */
     @media print {
-      body { background: #ffffff; }
+      @page { size: letter portrait; margin: 0.55in 0.5in; }
+      body {
+        background: #ffffff;
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+      }
       .top-bar { display: none; }
       .resume {
         max-width: 100%;
@@ -360,7 +365,11 @@
         border-radius: 0;
         box-shadow: none;
       }
-      .resume-body { gap: 36px; }
+      .resume-header { padding: 32px 40px 28px; }
+      .resume-body { gap: 32px; padding: 32px 40px; }
+      .exp-item { break-inside: avoid; page-break-inside: avoid; }
+      .section { break-inside: avoid; page-break-inside: avoid; }
+      .section-title { break-after: avoid; page-break-after: avoid; }
     }
 
     /* ── Mobile ── */
@@ -381,7 +390,7 @@
     <span>
       <a href="index.html">&larr; Back to dextermiller.com</a>
     </span>
-    <button class="print-btn" onclick="window.print()">Print / Save as PDF</button>
+    <button class="print-btn" onclick="window.print()">&#8595; Download Resume</button>
   </div>
 
   <div class="resume">


### PR DESCRIPTION
## Summary

- Renames "Print / Save as PDF" button to "↓ Download Resume"
- Adds `@page` rule (letter size, 0.55in vertical / 0.5in horizontal margins) for a clean PDF page
- Adds `print-color-adjust: exact` so the dark header gradient and skill tag backgrounds render in the saved PDF instead of stripping to white
- Tightens header/body padding in print mode to align with page margins
- Adds `break-inside: avoid` on experience items, sections, and section titles to prevent content splitting mid-entry across pages

## Test plan

- [ ] Open `resume.html` in browser, click "↓ Download Resume" — browser print dialog opens
- [ ] Save as PDF (letter, no extra margins) — verify header gradient prints in dark navy, skill tags retain background color
- [ ] Verify no experience entry or section title splits across a page break
- [ ] Verify top bar (Back link + button) is hidden in the PDF output

https://claude.ai/code/session_01Y3ZzE2DTtjTiAupPLyh5zw