### PR TITLE
Add Calendar Puzzle game to projects page

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -1,0 +1,310 @@
+/* ── Calendar Puzzle ─────────────────────────────────────────────────────── */
+
+.calendar-puzzle-wrapper {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+/* Date selectors */
+.cal-date-selectors {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.cal-select-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.cal-select-group label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--blue);
+}
+
+.cal-select-group select {
+  background: var(--bg-card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.875rem;
+  font-family: var(--font-body);
+  cursor: pointer;
+}
+
+/* Board */
+.cal-board {
+  --cal-cell: 50px;
+  display: grid;
+  grid-template-columns: repeat(7, var(--cal-cell));
+  gap: 3px;
+  user-select: none;
+}
+
+.cal-cell {
+  width: var(--cal-cell, 50px);
+  height: var(--cal-cell, 50px);
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.1s;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.cal-cell-label {
+  pointer-events: none;
+  font-size: 0.7rem;
+  font-weight: 500;
+  line-height: 1.1;
+  text-align: center;
+}
+
+.cal-cell--blocked {
+  background: transparent !important;
+  border: none !important;
+  pointer-events: none;
+  cursor: default !important;
+}
+
+.cal-cell--target {
+  background: #fff9c4;
+  border: 2px solid #f9a825;
+  color: #5a3e00;
+  font-weight: 700;
+}
+
+.cal-cell--empty {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.cal-cell--placed {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  font-weight: 700;
+}
+
+.cal-cell--preview-valid {
+  background: rgba(37, 99, 235, 0.25) !important;
+  border: 2px dashed var(--blue) !important;
+}
+
+.cal-cell--preview-invalid {
+  background: rgba(220, 38, 38, 0.2) !important;
+  border: 2px dashed #dc2626 !important;
+}
+
+/* Win banner */
+.cal-win-banner {
+  background: #16a34a;
+  color: #ffffff;
+  padding: 10px 32px;
+  border-radius: 24px;
+  font-weight: 700;
+  font-size: 1rem;
+  text-align: center;
+}
+
+/* No solutions message */
+.cal-no-solutions {
+  color: #dc2626;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 8px 20px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+}
+
+/* Controls */
+.cal-controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* Solution navigator */
+.cal-solution-nav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 20px;
+  font-size: 0.875rem;
+  color: var(--text);
+  box-shadow: var(--shadow);
+}
+
+.cal-solution-nav button {
+  background: var(--blue);
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 16px;
+  cursor: pointer;
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.4;
+  transition: background 0.15s;
+}
+
+.cal-solution-nav button:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.cal-solution-nav button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Piece tray */
+.cal-piece-tray {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  width: 100%;
+  max-width: 540px;
+  box-sizing: border-box;
+}
+
+.cal-piece-tray-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--blue);
+  text-align: center;
+  margin-bottom: 14px;
+  font-weight: 600;
+}
+
+.cal-pieces-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.cal-piece-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  transition: opacity 0.2s;
+}
+
+.cal-piece-wrapper.cal-piece--used {
+  opacity: 0.3;
+}
+
+.cal-rotate-btn {
+  background: var(--bg-card);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.cal-rotate-btn:hover:not(:disabled) {
+  background: var(--border);
+}
+
+.cal-rotate-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Legend */
+.cal-legend {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.cal-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cal-legend-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.cal-legend-swatch--empty {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+}
+
+.cal-legend-swatch--blocked {
+  background: transparent;
+  border: 1px dashed var(--border);
+}
+
+/* Dark mode */
+[data-theme="dark"] .cal-cell--target {
+  background: #451a03;
+  border-color: #d97706;
+  color: #fbbf24;
+}
+
+[data-theme="dark"] .cal-cell--empty {
+  background: #1c2333;
+  border-color: #30363d;
+  color: #8b949e;
+}
+
+[data-theme="dark"] .cal-no-solutions {
+  background: rgba(220, 38, 38, 0.1);
+  border-color: rgba(220, 38, 38, 0.3);
+  color: #f87171;
+}
+
+/* Responsive */
+@media (max-width: 520px) {
+  .cal-board {
+    --cal-cell: 42px;
+  }
+
+  .cal-cell-label {
+    font-size: 0.6rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .cal-board {
+    --cal-cell: 35px;
+  }
+
+  .cal-cell-label {
+    font-size: 0.55rem;
+  }
+}

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -9,22 +9,15 @@
   gap: 20px;
 }
 
-/* Date selectors */
-.cal-date-selectors {
-  display: flex;
-  gap: 16px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.cal-select-group {
+/* ── Date picker ─────────────────────────────────────────────────────────── */
+.cal-date-picker-wrap {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
 }
 
-.cal-select-group label {
+.cal-date-label {
   font-size: 0.7rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -32,24 +25,39 @@
   color: var(--blue);
 }
 
-.cal-select-group select {
+.cal-date-input {
   background: var(--bg-card);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 0.875rem;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 0.95rem;
   font-family: var(--font-body);
   cursor: pointer;
+  transition: border-color var(--transition);
+  text-align: center;
 }
 
-/* Board */
+.cal-date-input:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.cal-date-display {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+/* ── Board ───────────────────────────────────────────────────────────────── */
 .cal-board {
   --cal-cell: 50px;
   display: grid;
   grid-template-columns: repeat(7, var(--cal-cell));
   gap: 3px;
   user-select: none;
+  touch-action: none;
 }
 
 .cal-cell {
@@ -59,7 +67,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.1s;
+  transition: background 0.08s, transform 0.08s;
   box-sizing: border-box;
   position: relative;
 }
@@ -96,10 +104,15 @@
   border: 1px solid rgba(255, 255, 255, 0.2);
   color: white;
   font-weight: 700;
+  transition: filter 0.15s;
+}
+
+.cal-cell--placed:hover {
+  filter: brightness(1.15);
 }
 
 .cal-cell--preview-valid {
-  background: rgba(37, 99, 235, 0.25) !important;
+  background: rgba(37, 99, 235, 0.28) !important;
   border: 2px dashed var(--blue) !important;
 }
 
@@ -108,7 +121,7 @@
   border: 2px dashed #dc2626 !important;
 }
 
-/* Win banner */
+/* ── Win / no-solution banners ───────────────────────────────────────────── */
 .cal-win-banner {
   background: #16a34a;
   color: #ffffff;
@@ -117,12 +130,17 @@
   font-weight: 700;
   font-size: 1rem;
   text-align: center;
+  animation: calPop 0.25s ease;
 }
 
-/* No solutions message */
+@keyframes calPop {
+  from { transform: scale(0.85); opacity: 0; }
+  to   { transform: scale(1);    opacity: 1; }
+}
+
 .cal-no-solutions {
   color: #dc2626;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
   font-weight: 600;
   text-align: center;
   padding: 8px 20px;
@@ -131,7 +149,7 @@
   border-radius: 8px;
 }
 
-/* Controls */
+/* ── Controls ────────────────────────────────────────────────────────────── */
 .cal-controls {
   display: flex;
   gap: 10px;
@@ -139,55 +157,79 @@
   justify-content: center;
 }
 
-/* Solution navigator */
+/* ── Solution navigator ──────────────────────────────────────────────────── */
 .cal-solution-nav {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 10px;
-  padding: 8px 20px;
+  padding: 8px 16px;
   font-size: 0.875rem;
   color: var(--text);
   box-shadow: var(--shadow);
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
-.cal-solution-nav button {
+.cal-solution-nav .cal-sol-arrow {
   background: var(--blue);
   color: #ffffff;
   border: none;
   border-radius: 6px;
-  padding: 4px 16px;
+  padding: 4px 14px;
   cursor: pointer;
-  font-size: 1.15rem;
+  font-size: 1.2rem;
   font-weight: 700;
   line-height: 1.4;
   transition: background 0.15s;
 }
 
-.cal-solution-nav button:hover:not(:disabled) {
+.cal-solution-nav .cal-sol-arrow:hover:not(:disabled) {
   background: #1d4ed8;
 }
 
-.cal-solution-nav button:disabled {
+.cal-solution-nav .cal-sol-arrow:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
 
-/* Piece tray */
+.cal-sol-count {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.cal-back-play-btn {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.cal-back-play-btn:hover {
+  color: var(--blue);
+  border-color: var(--blue);
+}
+
+/* ── Piece tray ──────────────────────────────────────────────────────────── */
 .cal-piece-tray {
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 12px;
-  padding: 16px;
+  padding: 16px 16px 12px;
   width: 100%;
-  max-width: 540px;
+  max-width: 560px;
   box-sizing: border-box;
 }
 
 .cal-piece-tray-label {
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--blue);
@@ -199,7 +241,7 @@
 .cal-pieces-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 14px;
   justify-content: center;
 }
 
@@ -207,42 +249,44 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   transition: opacity 0.2s;
 }
 
 .cal-piece-wrapper.cal-piece--used {
-  opacity: 0.3;
+  opacity: 0.25;
 }
 
 .cal-rotate-btn {
   background: var(--bg-card);
   color: var(--text-muted);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 2px 8px;
-  font-size: 0.7rem;
+  border-radius: 5px;
+  padding: 3px 10px;
+  font-size: 0.82rem;
   font-family: var(--font-body);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.12s, color 0.12s;
 }
 
 .cal-rotate-btn:hover:not(:disabled) {
-  background: var(--border);
+  background: var(--blue);
+  color: #ffffff;
+  border-color: var(--blue);
 }
 
 .cal-rotate-btn:disabled {
-  opacity: 0.4;
+  opacity: 0.35;
   cursor: not-allowed;
 }
 
-/* Legend */
+/* ── Legend ──────────────────────────────────────────────────────────────── */
 .cal-legend {
   display: flex;
   gap: 16px;
   flex-wrap: wrap;
   justify-content: center;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: var(--text-muted);
 }
 
@@ -269,7 +313,7 @@
   border: 1px dashed var(--border);
 }
 
-/* Dark mode */
+/* ── Dark mode ───────────────────────────────────────────────────────────── */
 [data-theme="dark"] .cal-cell--target {
   background: #451a03;
   border-color: #d97706;
@@ -288,7 +332,7 @@
   color: #f87171;
 }
 
-/* Responsive */
+/* ── Responsive ──────────────────────────────────────────────────────────── */
 @media (max-width: 520px) {
   .cal-board {
     --cal-cell: 42px;
@@ -301,10 +345,10 @@
 
 @media (max-width: 380px) {
   .cal-board {
-    --cal-cell: 35px;
+    --cal-cell: 34px;
   }
 
   .cal-cell-label {
-    font-size: 0.55rem;
+    font-size: 0.54rem;
   }
 }

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -157,64 +157,87 @@
   justify-content: center;
 }
 
-/* ── Solution navigator ──────────────────────────────────────────────────── */
-.cal-solution-nav {
+/* ── Solution Panel ──────────────────────────────────────────────────────── */
+.cal-solution-panel {
+  background: var(--navy);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 20px 28px;
+  width: 100%;
+  max-width: 560px;
+  box-sizing: border-box;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 12px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 8px 16px;
-  font-size: 0.875rem;
-  color: var(--text);
-  box-shadow: var(--shadow);
-  flex-wrap: wrap;
-  justify-content: center;
+  gap: 16px;
 }
 
-.cal-solution-nav .cal-sol-arrow {
+.cal-solution-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.cal-solution-panel-title {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  color: #94a3b8;
+}
+
+.cal-solution-panel-nav {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.cal-sol-arrow {
   background: var(--blue);
   color: #ffffff;
   border: none;
-  border-radius: 6px;
-  padding: 4px 14px;
+  border-radius: 8px;
+  padding: 6px 20px;
   cursor: pointer;
-  font-size: 1.2rem;
+  font-size: 1.4rem;
   font-weight: 700;
   line-height: 1.4;
   transition: background 0.15s;
 }
 
-.cal-solution-nav .cal-sol-arrow:hover:not(:disabled) {
+.cal-sol-arrow:hover:not(:disabled) {
   background: #1d4ed8;
 }
 
-.cal-solution-nav .cal-sol-arrow:disabled {
-  opacity: 0.4;
+.cal-sol-arrow:disabled {
+  opacity: 0.35;
   cursor: not-allowed;
 }
 
 .cal-sol-count {
   font-weight: 600;
-  color: var(--text);
+  color: #ffffff;
+  font-size: 0.9rem;
+  min-width: 150px;
+  text-align: center;
 }
 
-.cal-back-play-btn {
-  background: transparent;
-  color: var(--text-muted);
-  border: 1px solid var(--border);
+.cal-solution-back-btn {
+  background: rgba(255, 255, 255, 0.07);
+  color: #94a3b8;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 6px;
-  padding: 4px 10px;
+  padding: 5px 12px;
   font-size: 0.78rem;
   font-family: var(--font-body);
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, background 0.15s;
 }
 
-.cal-back-play-btn:hover {
-  color: var(--blue);
-  border-color: var(--blue);
+.cal-solution-back-btn:hover {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.14);
 }
 
 /* ── Piece tray ──────────────────────────────────────────────────────────── */
@@ -280,38 +303,6 @@
   cursor: not-allowed;
 }
 
-/* ── Legend ──────────────────────────────────────────────────────────────── */
-.cal-legend {
-  display: flex;
-  gap: 16px;
-  flex-wrap: wrap;
-  justify-content: center;
-  font-size: 0.78rem;
-  color: var(--text-muted);
-}
-
-.cal-legend-item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.cal-legend-swatch {
-  width: 14px;
-  height: 14px;
-  border-radius: 3px;
-  flex-shrink: 0;
-}
-
-.cal-legend-swatch--empty {
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-}
-
-.cal-legend-swatch--blocked {
-  background: transparent;
-  border: 1px dashed var(--border);
-}
 
 /* ── Dark mode ───────────────────────────────────────────────────────────── */
 [data-theme="dark"] .cal-cell--target {

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -101,7 +101,7 @@
 }
 
 .cal-cell--placed {
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 2px solid rgba(0, 0, 0, 0.28);
   color: white;
   font-weight: 700;
   transition: filter 0.15s;

--- a/js/calendar-worker.js
+++ b/js/calendar-worker.js
@@ -1,0 +1,136 @@
+'use strict';
+
+// ── Board Definition ──────────────────────────────────────────────────────────
+var MONTHS   = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+var DAYS     = (function() { var a=[]; for(var i=1;i<=31;i++) a.push(String(i)); return a; }());
+var WEEKDAYS = ['Sun','Mon','Tues','Wed','Thur','Fri','Sat'];
+
+var BOARD_CELLS = {};
+var LABEL_TO_RC = {};
+
+(function buildBoard() {
+  function add(r, c, lbl) {
+    BOARD_CELLS[r + ',' + c] = lbl;
+    LABEL_TO_RC[lbl] = r + ',' + c;
+  }
+  MONTHS.slice(0, 6).forEach(function(m, i) { add(0, i, m); });
+  MONTHS.slice(6).forEach(function(m, i)    { add(1, i, m); });
+  var d = 0;
+  for (var r = 2; r <= 5; r++) {
+    for (var c = 0; c < 7; c++) { add(r, c, DAYS[d++]); }
+  }
+  [DAYS[28], DAYS[29], DAYS[30], 'Sun', 'Mon', 'Tues', 'Wed'].forEach(function(lbl, c) { add(6, c, lbl); });
+  ['Thur', 'Fri', 'Sat'].forEach(function(lbl, i) { add(7, i + 4, lbl); });
+}());
+
+var ALL_VALID    = (function() { var s = new Set(); Object.keys(BOARD_CELLS).forEach(function(k){ s.add(k); }); return s; }());
+var PERM_BLOCKED = new Set(['0,6','1,6','7,0','7,1','7,2','7,3']);
+
+// ── Piece Squares ─────────────────────────────────────────────────────────────
+// 10 pieces totalling 47 squares to fill 47 board cells (50 valid − 3 date targets)
+var PIECE_SQUARES = [
+  [[0,0],[0,1],[1,0],[2,0]],           // 0: L-tetromino        (4 sq)
+  [[0,1],[1,1],[2,0],[2,1],[2,2]],     // 1: T-pentomino        (5 sq)
+  [[0,0],[0,1],[1,1],[1,2]],           // 2: S-tetromino        (4 sq)
+  [[0,0],[1,0],[2,0],[3,0],[3,1]],     // 3: L-pentomino        (5 sq)
+  [[0,0],[0,1],[0,2],[1,0],[1,2]],     // 4: U-pentomino        (5 sq)
+  [[0,0],[0,1],[1,0],[1,1],[2,0]],     // 5: P-pentomino        (5 sq) — 2×2 box + extra
+  [[0,1],[1,0],[1,1],[2,0],[3,0]],     // 6: skew-pentomino     (5 sq)
+  [[0,0],[1,0],[2,0],[3,0]],           // 7: I-tetromino        (4 sq)
+  [[0,0],[1,0],[2,0],[2,1],[2,2]],     // 8: J-pentomino        (5 sq)
+  [[0,0],[0,1],[1,1],[2,1],[2,2]],     // 9: S-pentomino        (5 sq)
+];
+
+// ── Orientation helpers ───────────────────────────────────────────────────────
+function normalize(sqs) {
+  var minR = Infinity, minC = Infinity;
+  for (var i = 0; i < sqs.length; i++) { if (sqs[i][0] < minR) minR = sqs[i][0]; if (sqs[i][1] < minC) minC = sqs[i][1]; }
+  return sqs.map(function(s) { return [s[0] - minR, s[1] - minC]; })
+            .sort(function(a, b) { return a[0] - b[0] || a[1] - b[1]; });
+}
+function rot90(sqs)  { return normalize(sqs.map(function(s) { return [s[1], -s[0]]; })); }
+function flipH(sqs)  { var mx = 0; sqs.forEach(function(s){ if(s[1]>mx) mx=s[1]; }); return normalize(sqs.map(function(s){ return [s[0], mx-s[1]]; })); }
+function sqKey(sqs)  { return normalize(sqs).map(function(s){ return s.join(','); }).join('|'); }
+function getAllOrientations(sqs) {
+  var seen = new Set(), res = [], cur = sqs;
+  for (var f = 0; f < 2; f++) {
+    for (var r = 0; r < 4; r++) {
+      var n = normalize(cur), k = sqKey(n);
+      if (!seen.has(k)) { seen.add(k); res.push(n); }
+      cur = rot90(cur);
+    }
+    cur = flipH(cur);
+  }
+  return res;
+}
+var PIECE_ORIENTATIONS = PIECE_SQUARES.map(getAllOrientations);
+
+// ── Solver ────────────────────────────────────────────────────────────────────
+function solve(targetMonth, targetDay, targetWeekday, maxSols) {
+  var targetRCs = new Set();
+  [LABEL_TO_RC[targetMonth], LABEL_TO_RC[targetDay], LABEL_TO_RC[targetWeekday]].forEach(function(v) { if (v) targetRCs.add(v); });
+
+  var toFill = [];
+  for (var r = 0; r < 8; r++) {
+    for (var c = 0; c < 7; c++) {
+      var k = r + ',' + c;
+      if (ALL_VALID.has(k) && !PERM_BLOCKED.has(k) && !targetRCs.has(k)) toFill.push(k);
+    }
+  }
+
+  var solutions = [];
+  var board     = {};
+  var used      = [false,false,false,false,false,false,false,false,false,false];
+  var remaining = new Set(toFill);
+
+  function bt() {
+    if (remaining.size === 0) {
+      solutions.push(Object.assign({}, board));
+      return solutions.length >= maxSols;
+    }
+
+    // Always fill the first remaining cell — minimises branching factor
+    var first = remaining.values().next().value;
+    var parts = first.split(',');
+    var fr = parseInt(parts[0], 10), fc = parseInt(parts[1], 10);
+
+    for (var pid = 0; pid < 10; pid++) {
+      if (used[pid]) continue;
+      var orients = PIECE_ORIENTATIONS[pid];
+      for (var oi = 0; oi < orients.length; oi++) {
+        var orient = orients[oi];
+        for (var si = 0; si < orient.length; si++) {
+          var dr = fr - orient[si][0], dc = fc - orient[si][1];
+          var placed = [];
+          var ok = true;
+          for (var pi = 0; pi < orient.length; pi++) {
+            var pk = (orient[pi][0] + dr) + ',' + (orient[pi][1] + dc);
+            if (!remaining.has(pk)) { ok = false; break; }
+            placed.push(pk);
+          }
+          if (!ok) continue;
+          for (var i = 0; i < placed.length; i++) { board[placed[i]] = pid; remaining.delete(placed[i]); }
+          used[pid] = true;
+          if (bt()) return true;
+          used[pid] = false;
+          for (var j = 0; j < placed.length; j++) { delete board[placed[j]]; remaining.add(placed[j]); }
+        }
+      }
+    }
+    return false;
+  }
+
+  bt();
+  return solutions;
+}
+
+// ── Message handler ───────────────────────────────────────────────────────────
+self.onmessage = function(e) {
+  var d = e.data;
+  try {
+    var solutions = solve(d.month, d.day, d.weekday, d.maxSols || 50);
+    self.postMessage({ ok: true, solutions: solutions });
+  } catch (err) {
+    self.postMessage({ ok: false, error: String(err) });
+  }
+};

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -189,7 +189,7 @@
         `height:${CS - 3}px`,
         `background:${PIECE_DEFS[pieceId].color}`,
         'border-radius:5px',
-        'border:1px solid rgba(255,255,255,0.3)',
+        'border:2px solid rgba(0,0,0,0.22)',
       ].join(';');
       el.appendChild(sq);
     });
@@ -240,13 +240,19 @@
         const baseC     = cell[1] - drag.anchorC;
         const targetRCs = getTargetRCs();
         const placedMap = getPlacedCellMap();
-        const orient    = PIECE_ORIENTATIONS[drag.pieceId][orientIdxs[drag.pieceId]];
-        const placed    = orient.map(([pr, pc]) => ({ r: baseR + pr, c: baseC + pc }));
-        const isValid   = placed.every(({ r, c }) => {
+        const orient       = PIECE_ORIENTATIONS[drag.pieceId][orientIdxs[drag.pieceId]];
+        const placed       = orient.map(([pr, pc]) => ({ r: baseR + pr, c: baseC + pc }));
+        const conflictPids = new Set();
+        placed.forEach(({ r, c }) => {
+          const pid = placedMap[`${r},${c}`];
+          if (pid !== undefined) conflictPids.add(pid);
+        });
+        const isValid = placed.every(({ r, c }) => {
           const pk = `${r},${c}`;
-          return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedMap[pk] === undefined;
+          return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk);
         });
         if (isValid) {
+          conflictPids.forEach(cid => { delete placedPieces[cid]; });
           placedPieces[drag.pieceId] = placed;
         }
       }
@@ -290,11 +296,26 @@
     endDrag(t.clientX, t.clientY);
   });
 
-  // Escape cancels drag or deselects
+  // Escape cancels drag or deselects; arrow keys / R rotate selected piece
   document.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
       if (drag.active) { endDrag(); }
       else { selectedPiece = null; renderBoard(); renderPieceTray(); }
+      return;
+    }
+    if (selectedPiece !== null && !drag.active) {
+      const len = PIECE_ORIENTATIONS[selectedPiece].length;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowUp' || e.key === 'r' || e.key === 'R') {
+        e.preventDefault();
+        orientIdxs[selectedPiece] = (orientIdxs[selectedPiece] + 1) % len;
+        renderPieceTray();
+        renderBoard();
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        orientIdxs[selectedPiece] = (orientIdxs[selectedPiece] - 1 + len) % len;
+        renderPieceTray();
+        renderBoard();
+      }
     }
   });
 
@@ -366,7 +387,7 @@
       const placed   = orient.map(([pr, pc]) => ({ r: hr + pr, c: hc + pc }));
       const ok       = placed.every(({ r, c }) => {
         const pk = `${r},${c}`;
-        return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedMap[pk] === undefined;
+        return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk);
       });
       if (ok) {
         placed.forEach(({ r, c }) => validPrev.add(`${r},${c}`));
@@ -536,6 +557,7 @@
           `height:${SQ - 2}px`,
           `background:${p.color}`,
           'border-radius:3px',
+          'border:1px solid rgba(0,0,0,0.22)',
         ].join(';');
         canvas.appendChild(sq);
       });
@@ -575,7 +597,7 @@
       const rotBtn       = document.createElement('button');
       rotBtn.className   = 'cal-rotate-btn';
       rotBtn.textContent = '↻';
-      rotBtn.title       = 'Rotate';
+      rotBtn.title       = 'Rotate (→ or R key when piece is selected)';
       rotBtn.disabled    = isUsed;
       rotBtn.setAttribute('aria-label', `Rotate piece ${p.id + 1}`);
       rotBtn.addEventListener('click', e => {
@@ -602,28 +624,34 @@
 
     const placedMap = getPlacedCellMap();
 
-    if (placedMap[k] !== undefined) {
-      // Remove and re-select the piece
-      const pid = placedMap[k];
-      delete placedPieces[pid];
-      if (selectedPiece === null) selectedPiece = pid;
-      renderBoard();
-      renderPieceTray();
+    // Piece selected — place it, displacing any pieces already in the way
+    if (selectedPiece !== null) {
+      const orient       = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
+      const placed       = orient.map(([pr, pc]) => ({ r: r + pr, c: c + pc }));
+      const conflictPids = new Set();
+      placed.forEach(({ r: pr, c: pc }) => {
+        const pid = placedMap[`${pr},${pc}`];
+        if (pid !== undefined) conflictPids.add(pid);
+      });
+      const isValid = placed.every(({ r: pr, c: pc }) => {
+        const pk = `${pr},${pc}`;
+        return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk);
+      });
+      if (isValid) {
+        conflictPids.forEach(cid => { delete placedPieces[cid]; });
+        placedPieces[selectedPiece] = placed;
+        selectedPiece = null;
+        renderBoard();
+        renderPieceTray();
+      }
       return;
     }
 
-    if (selectedPiece === null) return;
-
-    const orient  = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
-    const placed  = orient.map(([pr, pc]) => ({ r: r + pr, c: c + pc }));
-    const isValid = placed.every(({ r: pr, c: pc }) => {
-      const pk = `${pr},${pc}`;
-      return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedMap[pk] === undefined;
-    });
-
-    if (isValid) {
-      placedPieces[selectedPiece] = placed;
-      selectedPiece = null;
+    // No piece selected — pick up whatever piece is at the clicked cell
+    if (placedMap[k] !== undefined) {
+      const pid = placedMap[k];
+      delete placedPieces[pid];
+      selectedPiece = pid;
       renderBoard();
       renderPieceTray();
     }

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -10,10 +10,7 @@
   const LABEL_TO_RC = {};
 
   (function buildBoard() {
-    function add(r, c, lbl) {
-      BOARD_CELLS[`${r},${c}`] = lbl;
-      LABEL_TO_RC[lbl] = `${r},${c}`;
-    }
+    function add(r, c, lbl) { BOARD_CELLS[`${r},${c}`] = lbl; LABEL_TO_RC[lbl] = `${r},${c}`; }
     MONTHS.slice(0, 6).forEach((m, i) => add(0, i, m));
     MONTHS.slice(6).forEach((m, i)    => add(1, i, m));
     let d = 0;
@@ -23,22 +20,21 @@
   }());
 
   const ALL_VALID    = new Set(Object.keys(BOARD_CELLS));
-  const PERM_BLOCKED = new Set(['0,6', '1,6', '7,0', '7,1', '7,2', '7,3']);
+  const PERM_BLOCKED = new Set(['0,6','1,6','7,0','7,1','7,2','7,3']);
 
   // ── Piece Definitions ─────────────────────────────────────────────────────────
-  // 10 pieces totalling 47 squares — matches the 47 cells that need covering
-  // (50 valid board cells minus 3 highlighted date cells)
+  // 10 pieces totalling 47 squares = 50 valid board cells − 3 date targets
   const PIECE_DEFS = [
-    { id: 0, color: '#e74c3c', squares: [[0,0],[0,1],[1,0],[2,0]]         },  // L-tetromino
-    { id: 1, color: '#e67e22', squares: [[0,1],[1,1],[2,0],[2,1],[2,2]]   },  // T-pentomino
-    { id: 2, color: '#d4ac0d', squares: [[0,0],[0,1],[1,1],[1,2]]         },  // S-tetromino
-    { id: 3, color: '#27ae60', squares: [[0,0],[1,0],[2,0],[3,0],[3,1]]   },  // L-pentomino
-    { id: 4, color: '#1abc9c', squares: [[0,0],[0,1],[0,2],[1,0],[1,2]]   },  // U-pentomino
-    { id: 5, color: '#3498db', squares: [[0,0],[0,1],[1,0],[1,1],[2,0]]   },  // P-pentomino (2×2 box + extra)
-    { id: 6, color: '#9b59b6', squares: [[0,1],[1,0],[1,1],[2,0],[3,0]]   },  // skew-pentomino
-    { id: 7, color: '#e91e63', squares: [[0,0],[1,0],[2,0],[3,0]]         },  // I-tetromino
-    { id: 8, color: '#00bcd4', squares: [[0,0],[1,0],[2,0],[2,1],[2,2]]   },  // J-pentomino
-    { id: 9, color: '#ff9800', squares: [[0,0],[0,1],[1,1],[2,1],[2,2]]   },  // S-pentomino
+    { id:0, color:'#e74c3c', squares:[[0,0],[0,1],[1,0],[2,0]]         },  // L-tetromino
+    { id:1, color:'#e67e22', squares:[[0,1],[1,1],[2,0],[2,1],[2,2]]   },  // T-pentomino
+    { id:2, color:'#d4ac0d', squares:[[0,0],[0,1],[1,1],[1,2]]         },  // S-tetromino
+    { id:3, color:'#27ae60', squares:[[0,0],[1,0],[2,0],[3,0],[3,1]]   },  // L-pentomino
+    { id:4, color:'#1abc9c', squares:[[0,0],[0,1],[0,2],[1,0],[1,2]]   },  // U-pentomino
+    { id:5, color:'#3498db', squares:[[0,0],[0,1],[1,0],[1,1],[2,0]]   },  // P-pentomino (2×2 box + extra)
+    { id:6, color:'#9b59b6', squares:[[0,1],[1,0],[1,1],[2,0],[3,0]]   },  // skew-pentomino
+    { id:7, color:'#e91e63', squares:[[0,0],[1,0],[2,0],[3,0]]         },  // I-tetromino
+    { id:8, color:'#00bcd4', squares:[[0,0],[1,0],[2,0],[2,1],[2,2]]   },  // J-pentomino
+    { id:9, color:'#ff9800', squares:[[0,0],[0,1],[1,1],[2,1],[2,2]]   },  // S-pentomino
   ];
 
   // ── Orientation helpers ───────────────────────────────────────────────────────
@@ -69,34 +65,42 @@
   const PIECE_ORIENTATIONS = PIECE_DEFS.map(p => getAllOrientations(p.squares));
 
   // ── State ─────────────────────────────────────────────────────────────────────
-  function getTodayLabels() {
-    const now = new Date();
-    return {
-      month:   MONTHS[now.getMonth()],
-      day:     String(now.getDate()),
-      weekday: WEEKDAYS[now.getDay()],
-    };
+  function toInputDate(d) {
+    return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+  }
+  function labelsFromDate(d) {
+    return { month: MONTHS[d.getMonth()], day: String(d.getDate()), weekday: WEEKDAYS[d.getDay()] };
+  }
+  function parseInputDate(val) {
+    if (!val) return null;
+    const [y, m, d] = val.split('-').map(Number);
+    return new Date(y, m - 1, d);  // local time — no UTC shift
+  }
+  function formatDisplayDate(d) {
+    const days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+    const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+    return `${days[d.getDay()]}, ${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
   }
 
-  const today    = getTodayLabels();
-  let selMonth   = today.month;
-  let selDay     = today.day;
-  let selWeekday = today.weekday;
-  let mode          = 'play';   // 'play' | 'solution'
-  let placedPieces  = {};       // pieceId (number) -> [{r, c}]
-  let selectedPiece = null;
-  let orientIdxs    = Array(10).fill(0);
-  let solutions     = [];
-  let solIdx        = 0;
-  let hoverCell     = null;
+  const now       = new Date();
+  let currentDate = now;
+  let { month: selMonth, day: selDay, weekday: selWeekday } = labelsFromDate(now);
 
-  // ── Web Worker for async solving ──────────────────────────────────────────────
-  let solverWorker    = null;
-  let solverTimeout   = null;
+  let mode         = 'play';   // 'play' | 'solution'
+  let placedPieces = {};       // pieceId (number) -> [{r, c}]
+  let selectedPiece = null;
+  let orientIdxs   = Array(10).fill(0);
+  let solutions    = [];
+  let solIdx       = 0;
+  let hoverCell    = null;     // [baseR, baseC] where orient[0,0] lands for preview
+
+  // ── Web Worker ────────────────────────────────────────────────────────────────
+  let solverWorker  = null;
+  let solverTimeout = null;
 
   function abortSolver() {
-    if (solverTimeout)  { clearTimeout(solverTimeout); solverTimeout = null; }
-    if (solverWorker)   { solverWorker.terminate(); solverWorker = null; }
+    if (solverTimeout) { clearTimeout(solverTimeout); solverTimeout = null; }
+    if (solverWorker)  { solverWorker.terminate(); solverWorker = null; }
   }
 
   function runSolver() {
@@ -105,7 +109,6 @@
     solveBtn.disabled    = true;
 
     solverWorker = new Worker('js/calendar-worker.js');
-
     solverWorker.onmessage = function (e) {
       abortSolver();
       solutions = e.data.ok ? e.data.solutions : [];
@@ -115,7 +118,6 @@
       solveBtn.disabled    = false;
       renderBoard();
     };
-
     solverWorker.onerror = function () {
       abortSolver();
       solutions = [];
@@ -125,8 +127,7 @@
       solveBtn.disabled    = false;
       renderBoard();
     };
-
-    // Safety net: kill worker after 30 s and show no-solutions state
+    // Safety timeout
     solverTimeout = setTimeout(function () {
       abortSolver();
       solutions = [];
@@ -140,42 +141,198 @@
     solverWorker.postMessage({ month: selMonth, day: selDay, weekday: selWeekday, maxSols: 50 });
   }
 
-  // ── DOM references ────────────────────────────────────────────────────────────
-  const boardEl     = document.getElementById('calBoard');
-  const winBanner   = document.getElementById('calWinBanner');
-  const noSolsEl    = document.getElementById('calNoSolutions');
-  const solveBtn    = document.getElementById('calSolve');
-  const playModeBtn = document.getElementById('calPlayMode');
-  const resetBtn    = document.getElementById('calReset');
-  const solNav      = document.getElementById('calSolutionNav');
-  const prevSolBtn  = document.getElementById('calPrevSol');
-  const nextSolBtn  = document.getElementById('calNextSol');
-  const solCount    = document.getElementById('calSolCount');
-  const pieceTray   = document.getElementById('calPieceTray');
-  const piecesGrid  = document.getElementById('calPiecesGrid');
-  const monthSel    = document.getElementById('calMonth');
-  const daySel      = document.getElementById('calDay');
-  const weekdaySel  = document.getElementById('calWeekday');
+  // ── Drag & Drop ───────────────────────────────────────────────────────────────
+  const drag = {
+    active:   false,
+    pieceId:  null,
+    anchorR:  0,     // which square of the piece's orient is "under the cursor"
+    anchorC:  0,
+    ghostEl:  null,
+  };
 
-  // ── Populate selects ──────────────────────────────────────────────────────────
-  function populateSelect(el, options, selected) {
-    options.forEach(o => {
-      const opt       = document.createElement('option');
-      opt.value       = o;
-      opt.textContent = o;
-      if (o === selected) opt.selected = true;
-      el.appendChild(opt);
-    });
+  function getCellSize() {
+    return parseInt(getComputedStyle(boardEl).getPropertyValue('--cal-cell'), 10) || 50;
   }
-  populateSelect(monthSel,   MONTHS,   selMonth);
-  populateSelect(daySel,     DAYS,     selDay);
-  populateSelect(weekdaySel, WEEKDAYS, selWeekday);
+
+  function findClosestSquare(orient, pr, pc) {
+    let best = orient[0], bestDist = Infinity;
+    orient.forEach(([r, c]) => {
+      const d = (r - pr) ** 2 + (c - pc) ** 2;
+      if (d < bestDist) { bestDist = d; best = [r, c]; }
+    });
+    return best;
+  }
+
+  function createGhost(pieceId) {
+    const CS     = getCellSize();
+    const orient = PIECE_ORIENTATIONS[pieceId][orientIdxs[pieceId]];
+    const maxR   = Math.max(...orient.map(([r]) => r));
+    const maxC   = Math.max(...orient.map(([, c]) => c));
+    const el     = document.createElement('div');
+    el.style.cssText = [
+      'position:fixed',
+      'pointer-events:none',
+      'z-index:9999',
+      `width:${(maxC + 1) * CS}px`,
+      `height:${(maxR + 1) * CS}px`,
+      'opacity:0.82',
+      'top:0',
+      'left:0',
+    ].join(';');
+    orient.forEach(([r, c]) => {
+      const sq = document.createElement('div');
+      sq.style.cssText = [
+        'position:absolute',
+        `left:${c * CS + 1}px`,
+        `top:${r * CS + 1}px`,
+        `width:${CS - 3}px`,
+        `height:${CS - 3}px`,
+        `background:${PIECE_DEFS[pieceId].color}`,
+        'border-radius:5px',
+        'border:1px solid rgba(255,255,255,0.3)',
+      ].join(';');
+      el.appendChild(sq);
+    });
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function moveGhost(clientX, clientY) {
+    if (!drag.ghostEl) return;
+    const CS = getCellSize();
+    drag.ghostEl.style.left = `${clientX - drag.anchorC * CS - CS / 2}px`;
+    drag.ghostEl.style.top  = `${clientY - drag.anchorR * CS - CS / 2}px`;
+  }
+
+  function getBoardCellAt(x, y) {
+    const el = document.elementFromPoint(x, y);
+    if (!el) return null;
+    const cell = (el.id && /^cal-\d+-\d+$/.test(el.id)) ? el : el.parentElement;
+    if (!cell || !cell.id) return null;
+    const m = cell.id.match(/^cal-(\d+)-(\d+)$/);
+    return m ? [parseInt(m[1], 10), parseInt(m[2], 10)] : null;
+  }
+
+  function startDrag(pieceId, anchorR, anchorC, clientX, clientY) {
+    if (mode !== 'play') return;
+    // Pick up from board if already placed
+    if (placedPieces[pieceId]) {
+      delete placedPieces[pieceId];
+      renderBoard();
+      renderPieceTray();
+    }
+    selectedPiece  = null;
+    drag.active    = true;
+    drag.pieceId   = pieceId;
+    drag.anchorR   = anchorR;
+    drag.anchorC   = anchorC;
+    drag.ghostEl   = createGhost(pieceId);
+    document.body.style.userSelect = 'none';
+    moveGhost(clientX, clientY);
+  }
+
+  function endDrag(clientX, clientY) {
+    if (!drag.active) return;
+    if (clientX !== undefined && clientY !== undefined) {
+      const cell = getBoardCellAt(clientX, clientY);
+      if (cell) {
+        const baseR     = cell[0] - drag.anchorR;
+        const baseC     = cell[1] - drag.anchorC;
+        const targetRCs = getTargetRCs();
+        const placedMap = getPlacedCellMap();
+        const orient    = PIECE_ORIENTATIONS[drag.pieceId][orientIdxs[drag.pieceId]];
+        const placed    = orient.map(([pr, pc]) => ({ r: baseR + pr, c: baseC + pc }));
+        const isValid   = placed.every(({ r, c }) => {
+          const pk = `${r},${c}`;
+          return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedMap[pk] === undefined;
+        });
+        if (isValid) {
+          placedPieces[drag.pieceId] = placed;
+        }
+      }
+    }
+    if (drag.ghostEl) { drag.ghostEl.remove(); drag.ghostEl = null; }
+    drag.active   = false;
+    drag.pieceId  = null;
+    document.body.style.userSelect = '';
+    hoverCell = null;
+    renderBoard();
+    renderPieceTray();
+  }
+
+  // Mouse drag events
+  document.addEventListener('mousemove', e => {
+    if (!drag.active) return;
+    moveGhost(e.clientX, e.clientY);
+    const cell = getBoardCellAt(e.clientX, e.clientY);
+    hoverCell = cell ? [cell[0] - drag.anchorR, cell[1] - drag.anchorC] : null;
+    renderBoard();
+  });
+
+  document.addEventListener('mouseup', e => {
+    if (drag.active) endDrag(e.clientX, e.clientY);
+  });
+
+  // Touch drag events
+  document.addEventListener('touchmove', e => {
+    if (!drag.active) return;
+    e.preventDefault();
+    const t = e.touches[0];
+    moveGhost(t.clientX, t.clientY);
+    const cell = getBoardCellAt(t.clientX, t.clientY);
+    hoverCell = cell ? [cell[0] - drag.anchorR, cell[1] - drag.anchorC] : null;
+    renderBoard();
+  }, { passive: false });
+
+  document.addEventListener('touchend', e => {
+    if (!drag.active) return;
+    const t = e.changedTouches[0];
+    endDrag(t.clientX, t.clientY);
+  });
+
+  // Escape cancels drag or deselects
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') {
+      if (drag.active) { endDrag(); }
+      else { selectedPiece = null; renderBoard(); renderPieceTray(); }
+    }
+  });
+
+  // ── DOM references ────────────────────────────────────────────────────────────
+  const boardEl       = document.getElementById('calBoard');
+  const winBanner     = document.getElementById('calWinBanner');
+  const noSolsEl      = document.getElementById('calNoSolutions');
+  const solveBtn      = document.getElementById('calSolve');
+  const resetBtn      = document.getElementById('calReset');
+  const solNav        = document.getElementById('calSolutionNav');
+  const prevSolBtn    = document.getElementById('calPrevSol');
+  const nextSolBtn    = document.getElementById('calNextSol');
+  const solCount      = document.getElementById('calSolCount');
+  const backToPlayBtn = document.getElementById('calBackToPlay');
+  const pieceTray     = document.getElementById('calPieceTray');
+  const piecesGrid    = document.getElementById('calPiecesGrid');
+  const dateInput     = document.getElementById('calDateInput');
+  const dateDisplay   = document.getElementById('calDateDisplay');
+
+  // ── Date input init ───────────────────────────────────────────────────────────
+  dateInput.value = toInputDate(now);
+  dateDisplay.textContent = formatDisplayDate(now);
+
+  dateInput.addEventListener('change', () => {
+    const d = parseInputDate(dateInput.value);
+    if (!d || isNaN(d.getTime())) return;
+    currentDate = d;
+    const labels = labelsFromDate(d);
+    selMonth   = labels.month;
+    selDay     = labels.day;
+    selWeekday = labels.weekday;
+    dateDisplay.textContent = formatDisplayDate(d);
+    resetAll();
+  });
 
   // ── Derived helpers ───────────────────────────────────────────────────────────
   function getTargetRCs() {
-    return new Set(
-      [LABEL_TO_RC[selMonth], LABEL_TO_RC[selDay], LABEL_TO_RC[selWeekday]].filter(Boolean)
-    );
+    return new Set([LABEL_TO_RC[selMonth], LABEL_TO_RC[selDay], LABEL_TO_RC[selWeekday]].filter(Boolean));
   }
 
   function getPlacedCellMap() {
@@ -193,91 +350,78 @@
 
   // ── Board rendering ───────────────────────────────────────────────────────────
   function renderBoard() {
-    const targetRCs     = getTargetRCs();
-    const displayBoard  = getDisplayBoard();
-    const placedCellMap = getPlacedCellMap();
-    const usedIds       = new Set(Object.keys(placedPieces).map(Number));
-    const isWin         = mode === 'play' && usedIds.size === 10;
+    const targetRCs    = getTargetRCs();
+    const displayBoard = getDisplayBoard();
+    const placedMap    = getPlacedCellMap();
+    const usedIds      = new Set(Object.keys(placedPieces).map(Number));
+    const isWin        = mode === 'play' && usedIds.size === 10;
 
-    // Compute placement preview
-    const validPreview   = new Set();
-    const invalidPreview = new Set();
-    if (mode === 'play' && selectedPiece !== null && hoverCell) {
+    // Placement preview (works for both click-select and drag)
+    const validPrev   = new Set();
+    const invalidPrev = new Set();
+    const previewPid  = drag.active ? drag.pieceId : selectedPiece;
+    if (mode === 'play' && previewPid !== null && hoverCell) {
       const [hr, hc] = hoverCell;
-      const orient   = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
+      const orient   = PIECE_ORIENTATIONS[previewPid][orientIdxs[previewPid]];
       const placed   = orient.map(([pr, pc]) => ({ r: hr + pr, c: hc + pc }));
       const ok       = placed.every(({ r, c }) => {
         const pk = `${r},${c}`;
-        return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedCellMap[pk] === undefined;
+        return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedMap[pk] === undefined;
       });
       if (ok) {
-        placed.forEach(({ r, c }) => validPreview.add(`${r},${c}`));
+        placed.forEach(({ r, c }) => validPrev.add(`${r},${c}`));
       } else {
         placed.forEach(({ r, c }) => {
-          if (r >= 0 && r < 8 && c >= 0 && c < 7 && ALL_VALID.has(`${r},${c}`)) {
-            invalidPreview.add(`${r},${c}`);
-          }
+          if (r >= 0 && r < 8 && c >= 0 && c < 7 && ALL_VALID.has(`${r},${c}`)) invalidPrev.add(`${r},${c}`);
         });
       }
     }
 
-    // Update each cell
     for (let r = 0; r < 8; r++) {
       for (let c = 0; c < 7; c++) {
-        const k       = `${r},${c}`;
-        const cell    = document.getElementById(`cal-${r}-${c}`);
+        const k      = `${r},${c}`;
+        const cell   = document.getElementById(`cal-${r}-${c}`);
         if (!cell) continue;
-
-        const labelEl   = cell.querySelector('.cal-cell-label');
+        const lbl    = cell.querySelector('.cal-cell-label');
         const isBlocked = !ALL_VALID.has(k) || PERM_BLOCKED.has(k);
 
         cell.className        = 'cal-cell';
         cell.style.background = '';
         cell.style.cursor     = '';
 
-        if (isBlocked) {
-          cell.classList.add('cal-cell--blocked');
-          labelEl.textContent = '';
-          continue;
-        }
+        if (isBlocked) { cell.classList.add('cal-cell--blocked'); lbl.textContent = ''; continue; }
 
         const isTarget  = targetRCs.has(k);
-        const inValid   = validPreview.has(k);
-        const inInvalid = invalidPreview.has(k);
+        const inValid   = validPrev.has(k);
+        const inInvalid = invalidPrev.has(k);
         const pid       = displayBoard[k];
-        const lbl       = BOARD_CELLS[k] || '';
+        const label     = BOARD_CELLS[k] || '';
 
         if (isTarget) {
           cell.classList.add('cal-cell--target');
-          labelEl.textContent = lbl;
+          lbl.textContent = label;
         } else if (inValid) {
           cell.classList.add('cal-cell--preview-valid');
-          labelEl.textContent = '';
+          lbl.textContent = '';
         } else if (inInvalid) {
           cell.classList.add('cal-cell--preview-invalid');
-          labelEl.textContent = '';
+          lbl.textContent = '';
         } else if (pid !== undefined) {
           cell.classList.add('cal-cell--placed');
           cell.style.background = PIECE_DEFS[pid].color;
-          labelEl.textContent   = '';
-          if (mode === 'play') cell.style.cursor = 'pointer';
+          lbl.textContent = '';
+          if (mode === 'play') cell.style.cursor = 'grab';
         } else {
           cell.classList.add('cal-cell--empty');
-          labelEl.textContent = lbl;
-          if (mode === 'play' && selectedPiece !== null) cell.style.cursor = 'crosshair';
+          lbl.textContent = label;
+          if (mode === 'play' && (selectedPiece !== null || drag.active)) cell.style.cursor = 'crosshair';
         }
       }
     }
 
-    // Banners
     winBanner.hidden = !isWin;
     noSolsEl.hidden  = !(mode === 'solution' && solutions.length === 0);
 
-    // Play mode button highlight
-    playModeBtn.classList.toggle('btn-primary', mode === 'play');
-    playModeBtn.classList.toggle('btn-outline',  mode !== 'play');
-
-    // Solution navigator
     if (mode === 'solution' && solutions.length > 0) {
       solNav.hidden = false;
       const more    = solutions.length >= 50 ? ' (50+ exist)' : '';
@@ -288,7 +432,6 @@
       solNav.hidden = true;
     }
 
-    // Piece tray visibility
     pieceTray.hidden = mode !== 'play';
   }
 
@@ -303,15 +446,48 @@
         cell.className = 'cal-cell';
         cell.setAttribute('role', 'gridcell');
 
-        const labelEl     = document.createElement('span');
-        labelEl.className = 'cal-cell-label';
-        cell.appendChild(labelEl);
+        const lbl     = document.createElement('span');
+        lbl.className = 'cal-cell-label';
+        cell.appendChild(lbl);
 
         const isBlocked = !ALL_VALID.has(k) || PERM_BLOCKED.has(k);
         if (!isBlocked) {
-          cell.addEventListener('click',      () => handleCellClick(r, c));
-          cell.addEventListener('mouseenter', () => { hoverCell = [r, c]; renderBoard(); });
-          cell.addEventListener('mouseleave', () => { hoverCell = null;   renderBoard(); });
+          cell.addEventListener('mouseenter', () => {
+            if (drag.active) return; // drag handles its own hover
+            hoverCell = selectedPiece !== null ? [r, c] : null;
+            renderBoard();
+          });
+          cell.addEventListener('mouseleave', () => {
+            if (drag.active) return;
+            hoverCell = null;
+            renderBoard();
+          });
+          cell.addEventListener('click', () => handleCellClick(r, c));
+          // Board pieces can be dragged off the board
+          cell.addEventListener('mousedown', e => {
+            if (mode !== 'play') return;
+            const pid = getPlacedCellMap()[`${r},${c}`];
+            if (pid === undefined) return;
+            e.preventDefault();
+            // Compute anchor: which square of the orient is at (r,c)?
+            const orient = PIECE_ORIENTATIONS[pid][orientIdxs[pid]];
+            const base0  = placedPieces[pid][0];
+            const baseR  = base0.r - orient[0][0];
+            const baseC  = base0.c - orient[0][1];
+            startDrag(pid, r - baseR, c - baseC, e.clientX, e.clientY);
+          });
+          cell.addEventListener('touchstart', e => {
+            if (mode !== 'play') return;
+            const pid = getPlacedCellMap()[`${r},${c}`];
+            if (pid === undefined) return;
+            e.preventDefault();
+            const t      = e.touches[0];
+            const orient = PIECE_ORIENTATIONS[pid][orientIdxs[pid]];
+            const base0  = placedPieces[pid][0];
+            const baseR  = base0.r - orient[0][0];
+            const baseC  = base0.c - orient[0][1];
+            startDrag(pid, r - baseR, c - baseC, t.clientX, t.clientY);
+          }, { passive: false });
         }
         boardEl.appendChild(cell);
       }
@@ -322,6 +498,7 @@
   function renderPieceTray() {
     piecesGrid.innerHTML = '';
     const usedIds = new Set(Object.keys(placedPieces).map(Number));
+    const SQ      = 18; // mini-square size in tray (px)
 
     PIECE_DEFS.forEach(p => {
       const isUsed = usedIds.has(p.id);
@@ -329,24 +506,24 @@
       const orient = PIECE_ORIENTATIONS[p.id][orientIdxs[p.id]];
       const maxR   = Math.max(...orient.map(([r]) => r));
       const maxC   = Math.max(...orient.map(([, c]) => c));
-      const SQ     = 14;
 
       const wrapper     = document.createElement('div');
       wrapper.className = 'cal-piece-wrapper' + (isUsed ? ' cal-piece--used' : '');
 
-      const canvas          = document.createElement('div');
-      canvas.className      = 'cal-piece-canvas';
-      canvas.style.cssText  = [
+      const canvas         = document.createElement('div');
+      canvas.className     = 'cal-piece-canvas';
+      canvas.style.cssText = [
         'position:relative',
         `width:${(maxC + 1) * SQ + 4}px`,
         `height:${(maxR + 1) * SQ + 4}px`,
-        'min-width:32px',
-        'min-height:32px',
+        'min-width:36px',
+        'min-height:36px',
         `outline:2px solid ${isSel ? p.color : 'transparent'}`,
-        'border-radius:4px',
+        'border-radius:5px',
         'padding:2px',
-        `cursor:${isUsed ? 'default' : 'pointer'}`,
-        'transition:outline-color 0.15s',
+        `cursor:${isUsed ? 'default' : 'grab'}`,
+        'transition:outline-color 0.15s,transform 0.1s',
+        isSel ? 'transform:scale(1.08)' : '',
       ].join(';');
 
       orient.forEach(([pr, pc]) => {
@@ -355,31 +532,57 @@
           'position:absolute',
           `left:${pc * SQ + 2}px`,
           `top:${pr * SQ + 2}px`,
-          `width:${SQ - 1}px`,
-          `height:${SQ - 1}px`,
+          `width:${SQ - 2}px`,
+          `height:${SQ - 2}px`,
           `background:${p.color}`,
-          'border-radius:2px',
+          'border-radius:3px',
         ].join(';');
         canvas.appendChild(sq);
       });
 
+      // Click to select (alternative to drag)
       if (!isUsed) {
-        canvas.addEventListener('click', () => {
+        canvas.addEventListener('click', e => {
+          if (drag.active) return;
           selectedPiece = (selectedPiece === p.id) ? null : p.id;
           renderPieceTray();
           renderBoard();
         });
+
+        // Drag from tray
+        canvas.addEventListener('mousedown', e => {
+          if (mode !== 'play') return;
+          e.preventDefault();
+          const rect = canvas.getBoundingClientRect();
+          const mx   = e.clientX - rect.left - 2;
+          const my   = e.clientY - rect.top  - 2;
+          const anchorSq = findClosestSquare(orient, Math.floor(my / SQ), Math.floor(mx / SQ));
+          startDrag(p.id, anchorSq[0], anchorSq[1], e.clientX, e.clientY);
+        });
+
+        canvas.addEventListener('touchstart', e => {
+          if (mode !== 'play') return;
+          e.preventDefault();
+          const t    = e.touches[0];
+          const rect = canvas.getBoundingClientRect();
+          const mx   = t.clientX - rect.left - 2;
+          const my   = t.clientY - rect.top  - 2;
+          const anchorSq = findClosestSquare(orient, Math.floor(my / SQ), Math.floor(mx / SQ));
+          startDrag(p.id, anchorSq[0], anchorSq[1], t.clientX, t.clientY);
+        }, { passive: false });
       }
 
-      const rotBtn          = document.createElement('button');
-      rotBtn.className      = 'cal-rotate-btn';
-      rotBtn.textContent    = '↻ rotate';
-      rotBtn.disabled       = isUsed;
+      const rotBtn       = document.createElement('button');
+      rotBtn.className   = 'cal-rotate-btn';
+      rotBtn.textContent = '↻';
+      rotBtn.title       = 'Rotate';
+      rotBtn.disabled    = isUsed;
       rotBtn.setAttribute('aria-label', `Rotate piece ${p.id + 1}`);
       rotBtn.addEventListener('click', e => {
         e.stopPropagation();
-        if (isUsed) return;
+        if (isUsed || drag.active) return;
         orientIdxs[p.id] = (orientIdxs[p.id] + 1) % PIECE_ORIENTATIONS[p.id].length;
+        // Rebuild ghost if currently dragging this piece
         renderPieceTray();
         renderBoard();
       });
@@ -390,18 +593,18 @@
     });
   }
 
-  // ── Cell click handler ────────────────────────────────────────────────────────
+  // ── Click-to-place handler ────────────────────────────────────────────────────
   function handleCellClick(r, c) {
-    if (mode !== 'play') return;
+    if (mode !== 'play' || drag.active) return;
     const k         = `${r},${c}`;
     const targetRCs = getTargetRCs();
     if (PERM_BLOCKED.has(k) || !ALL_VALID.has(k) || targetRCs.has(k)) return;
 
-    const placedCellMap = getPlacedCellMap();
+    const placedMap = getPlacedCellMap();
 
-    // Click an occupied cell → remove that piece and re-select it
-    if (placedCellMap[k] !== undefined) {
-      const pid = placedCellMap[k];
+    if (placedMap[k] !== undefined) {
+      // Remove and re-select the piece
+      const pid = placedMap[k];
       delete placedPieces[pid];
       if (selectedPiece === null) selectedPiece = pid;
       renderBoard();
@@ -415,7 +618,7 @@
     const placed  = orient.map(([pr, pc]) => ({ r: r + pr, c: c + pc }));
     const isValid = placed.every(({ r: pr, c: pc }) => {
       const pk = `${pr},${pc}`;
-      return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedCellMap[pk] === undefined;
+      return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedMap[pk] === undefined;
     });
 
     if (isValid) {
@@ -429,12 +632,14 @@
   // ── Reset ─────────────────────────────────────────────────────────────────────
   function resetAll() {
     abortSolver();
+    if (drag.active) endDrag();
     placedPieces         = {};
     selectedPiece        = null;
     solutions            = [];
     solIdx               = 0;
     mode                 = 'play';
     orientIdxs           = Array(10).fill(0);
+    hoverCell            = null;
     solveBtn.textContent = 'Show Solutions';
     solveBtn.disabled    = false;
     renderPieceTray();
@@ -442,26 +647,19 @@
   }
 
   // ── Event listeners ───────────────────────────────────────────────────────────
-  monthSel.addEventListener('change',   e => { selMonth   = e.target.value; resetAll(); });
-  daySel.addEventListener('change',     e => { selDay     = e.target.value; resetAll(); });
-  weekdaySel.addEventListener('change', e => { selWeekday = e.target.value; resetAll(); });
-
   solveBtn.addEventListener('click', runSolver);
-
-  playModeBtn.addEventListener('click', () => {
-    mode = 'play';
-    renderBoard();
-    renderPieceTray();
-  });
-
   resetBtn.addEventListener('click', resetAll);
 
   prevSolBtn.addEventListener('click', () => {
     if (solIdx > 0) { solIdx--; renderBoard(); }
   });
-
   nextSolBtn.addEventListener('click', () => {
     if (solIdx < solutions.length - 1) { solIdx++; renderBoard(); }
+  });
+  backToPlayBtn.addEventListener('click', () => {
+    mode = 'play';
+    renderBoard();
+    renderPieceTray();
   });
 
   // ── Init ──────────────────────────────────────────────────────────────────────

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -26,17 +26,19 @@
   const PERM_BLOCKED = new Set(['0,6', '1,6', '7,0', '7,1', '7,2', '7,3']);
 
   // ── Piece Definitions ─────────────────────────────────────────────────────────
+  // 10 pieces totalling 47 squares — matches the 47 cells that need covering
+  // (50 valid board cells minus 3 highlighted date cells)
   const PIECE_DEFS = [
-    { id: 0, color: '#e74c3c', squares: [[0,0],[0,1],[1,0],[2,0]]           },
-    { id: 1, color: '#e67e22', squares: [[0,1],[1,1],[2,0],[2,1],[2,2]]     },
-    { id: 2, color: '#d4ac0d', squares: [[0,0],[0,1],[1,1],[1,2]]           },
-    { id: 3, color: '#27ae60', squares: [[0,0],[1,0],[2,0],[3,0],[3,1]]     },
-    { id: 4, color: '#1abc9c', squares: [[0,0],[0,1],[0,2],[1,0],[1,2]]     },
-    { id: 5, color: '#3498db', squares: [[0,1],[0,2],[1,0],[1,1]]           },
-    { id: 6, color: '#9b59b6', squares: [[0,1],[1,0],[1,1],[2,0],[3,0]]     },
-    { id: 7, color: '#e91e63', squares: [[0,0],[1,0],[2,0],[3,0]]           },
-    { id: 8, color: '#00bcd4', squares: [[0,0],[1,0],[2,0],[2,1],[2,2]]     },
-    { id: 9, color: '#ff9800', squares: [[0,0],[0,1],[1,1],[2,1],[2,2]]     },
+    { id: 0, color: '#e74c3c', squares: [[0,0],[0,1],[1,0],[2,0]]         },  // L-tetromino
+    { id: 1, color: '#e67e22', squares: [[0,1],[1,1],[2,0],[2,1],[2,2]]   },  // T-pentomino
+    { id: 2, color: '#d4ac0d', squares: [[0,0],[0,1],[1,1],[1,2]]         },  // S-tetromino
+    { id: 3, color: '#27ae60', squares: [[0,0],[1,0],[2,0],[3,0],[3,1]]   },  // L-pentomino
+    { id: 4, color: '#1abc9c', squares: [[0,0],[0,1],[0,2],[1,0],[1,2]]   },  // U-pentomino
+    { id: 5, color: '#3498db', squares: [[0,0],[0,1],[1,0],[1,1],[2,0]]   },  // P-pentomino (2×2 box + extra)
+    { id: 6, color: '#9b59b6', squares: [[0,1],[1,0],[1,1],[2,0],[3,0]]   },  // skew-pentomino
+    { id: 7, color: '#e91e63', squares: [[0,0],[1,0],[2,0],[3,0]]         },  // I-tetromino
+    { id: 8, color: '#00bcd4', squares: [[0,0],[1,0],[2,0],[2,1],[2,2]]   },  // J-pentomino
+    { id: 9, color: '#ff9800', squares: [[0,0],[0,1],[1,1],[2,1],[2,2]]   },  // S-pentomino
   ];
 
   // ── Orientation helpers ───────────────────────────────────────────────────────
@@ -66,54 +68,6 @@
   }
   const PIECE_ORIENTATIONS = PIECE_DEFS.map(p => getAllOrientations(p.squares));
 
-  // ── Solver (backtracking) ─────────────────────────────────────────────────────
-  function solve(targetMonth, targetDay, targetWeekday, maxSols) {
-    const targetRCs = new Set(
-      [LABEL_TO_RC[targetMonth], LABEL_TO_RC[targetDay], LABEL_TO_RC[targetWeekday]].filter(Boolean)
-    );
-
-    const toFill = [];
-    for (let r = 0; r < 8; r++) {
-      for (let c = 0; c < 7; c++) {
-        const k = `${r},${c}`;
-        if (ALL_VALID.has(k) && !PERM_BLOCKED.has(k) && !targetRCs.has(k)) toFill.push(k);
-      }
-    }
-
-    const solutions = [];
-    const board     = {};
-    const used      = new Array(10).fill(false);
-    const remaining = new Set(toFill);
-
-    function bt() {
-      if (remaining.size === 0) {
-        solutions.push({ ...board });
-        return solutions.length >= maxSols;
-      }
-      const [first] = remaining;
-      const [fr, fc] = first.split(',').map(Number);
-      for (let pid = 0; pid < 10; pid++) {
-        if (used[pid]) continue;
-        for (const orient of PIECE_ORIENTATIONS[pid]) {
-          for (const [pr, pc] of orient) {
-            const dr = fr - pr, dc = fc - pc;
-            const placed = orient.map(([rr, cc]) => `${rr + dr},${cc + dc}`);
-            if (placed.every(k => remaining.has(k))) {
-              placed.forEach(k => { board[k] = pid; remaining.delete(k); });
-              used[pid] = true;
-              if (bt()) return true;
-              used[pid] = false;
-              placed.forEach(k => { delete board[k]; remaining.add(k); });
-            }
-          }
-        }
-      }
-      return false;
-    }
-    bt();
-    return solutions;
-  }
-
   // ── State ─────────────────────────────────────────────────────────────────────
   function getTodayLabels() {
     const now = new Date();
@@ -129,12 +83,62 @@
   let selDay     = today.day;
   let selWeekday = today.weekday;
   let mode          = 'play';   // 'play' | 'solution'
-  let placedPieces  = {};       // pieceId (number key) -> [{r, c}]
+  let placedPieces  = {};       // pieceId (number) -> [{r, c}]
   let selectedPiece = null;
   let orientIdxs    = Array(10).fill(0);
   let solutions     = [];
   let solIdx        = 0;
   let hoverCell     = null;
+
+  // ── Web Worker for async solving ──────────────────────────────────────────────
+  let solverWorker    = null;
+  let solverTimeout   = null;
+
+  function abortSolver() {
+    if (solverTimeout)  { clearTimeout(solverTimeout); solverTimeout = null; }
+    if (solverWorker)   { solverWorker.terminate(); solverWorker = null; }
+  }
+
+  function runSolver() {
+    abortSolver();
+    solveBtn.textContent = 'Solving…';
+    solveBtn.disabled    = true;
+
+    solverWorker = new Worker('js/calendar-worker.js');
+
+    solverWorker.onmessage = function (e) {
+      abortSolver();
+      solutions = e.data.ok ? e.data.solutions : [];
+      solIdx    = 0;
+      mode      = 'solution';
+      solveBtn.textContent = 'Show Solutions';
+      solveBtn.disabled    = false;
+      renderBoard();
+    };
+
+    solverWorker.onerror = function () {
+      abortSolver();
+      solutions = [];
+      solIdx    = 0;
+      mode      = 'solution';
+      solveBtn.textContent = 'Show Solutions';
+      solveBtn.disabled    = false;
+      renderBoard();
+    };
+
+    // Safety net: kill worker after 30 s and show no-solutions state
+    solverTimeout = setTimeout(function () {
+      abortSolver();
+      solutions = [];
+      solIdx    = 0;
+      mode      = 'solution';
+      solveBtn.textContent = 'Show Solutions';
+      solveBtn.disabled    = false;
+      renderBoard();
+    }, 30000);
+
+    solverWorker.postMessage({ month: selMonth, day: selDay, weekday: selWeekday, maxSols: 50 });
+  }
 
   // ── DOM references ────────────────────────────────────────────────────────────
   const boardEl     = document.getElementById('calBoard');
@@ -156,8 +160,8 @@
   // ── Populate selects ──────────────────────────────────────────────────────────
   function populateSelect(el, options, selected) {
     options.forEach(o => {
-      const opt     = document.createElement('option');
-      opt.value     = o;
+      const opt       = document.createElement('option');
+      opt.value       = o;
       opt.textContent = o;
       if (o === selected) opt.selected = true;
       el.appendChild(opt);
@@ -195,7 +199,7 @@
     const usedIds       = new Set(Object.keys(placedPieces).map(Number));
     const isWin         = mode === 'play' && usedIds.size === 10;
 
-    // Compute preview cells
+    // Compute placement preview
     const validPreview   = new Set();
     const invalidPreview = new Set();
     if (mode === 'play' && selectedPiece !== null && hoverCell) {
@@ -217,19 +221,19 @@
       }
     }
 
-    // Update each cell element
+    // Update each cell
     for (let r = 0; r < 8; r++) {
       for (let c = 0; c < 7; c++) {
-        const k    = `${r},${c}`;
-        const cell = document.getElementById(`cal-${r}-${c}`);
+        const k       = `${r},${c}`;
+        const cell    = document.getElementById(`cal-${r}-${c}`);
         if (!cell) continue;
 
         const labelEl   = cell.querySelector('.cal-cell-label');
         const isBlocked = !ALL_VALID.has(k) || PERM_BLOCKED.has(k);
 
-        cell.className     = 'cal-cell';
+        cell.className        = 'cal-cell';
         cell.style.background = '';
-        cell.style.cursor  = '';
+        cell.style.cursor     = '';
 
         if (isBlocked) {
           cell.classList.add('cal-cell--blocked');
@@ -269,7 +273,7 @@
     winBanner.hidden = !isWin;
     noSolsEl.hidden  = !(mode === 'solution' && solutions.length === 0);
 
-    // Play mode button state
+    // Play mode button highlight
     playModeBtn.classList.toggle('btn-primary', mode === 'play');
     playModeBtn.classList.toggle('btn-outline',  mode !== 'play');
 
@@ -277,18 +281,18 @@
     if (mode === 'solution' && solutions.length > 0) {
       solNav.hidden = false;
       const more    = solutions.length >= 50 ? ' (50+ exist)' : '';
-      solCount.textContent  = `Solution ${solIdx + 1} of ${solutions.length}${more}`;
-      prevSolBtn.disabled   = solIdx === 0;
-      nextSolBtn.disabled   = solIdx === solutions.length - 1;
+      solCount.textContent = `Solution ${solIdx + 1} of ${solutions.length}${more}`;
+      prevSolBtn.disabled  = solIdx === 0;
+      nextSolBtn.disabled  = solIdx === solutions.length - 1;
     } else {
       solNav.hidden = true;
     }
 
-    // Show/hide piece tray
+    // Piece tray visibility
     pieceTray.hidden = mode !== 'play';
   }
 
-  // ── Build board DOM (once) ────────────────────────────────────────────────────
+  // ── Build board DOM (once on load) ────────────────────────────────────────────
   function buildBoardDOM() {
     boardEl.innerHTML = '';
     for (let r = 0; r < 8; r++) {
@@ -299,8 +303,8 @@
         cell.className = 'cal-cell';
         cell.setAttribute('role', 'gridcell');
 
-        const labelEl       = document.createElement('span');
-        labelEl.className   = 'cal-cell-label';
+        const labelEl     = document.createElement('span');
+        labelEl.className = 'cal-cell-label';
         cell.appendChild(labelEl);
 
         const isBlocked = !ALL_VALID.has(k) || PERM_BLOCKED.has(k);
@@ -314,7 +318,7 @@
     }
   }
 
-  // ── Piece tray rendering ──────────────────────────────────────────────────────
+  // ── Piece tray ────────────────────────────────────────────────────────────────
   function renderPieceTray() {
     piecesGrid.innerHTML = '';
     const usedIds = new Set(Object.keys(placedPieces).map(Number));
@@ -327,35 +331,34 @@
       const maxC   = Math.max(...orient.map(([, c]) => c));
       const SQ     = 14;
 
-      const wrapper       = document.createElement('div');
-      wrapper.className   = 'cal-piece-wrapper' + (isUsed ? ' cal-piece--used' : '');
+      const wrapper     = document.createElement('div');
+      wrapper.className = 'cal-piece-wrapper' + (isUsed ? ' cal-piece--used' : '');
 
-      const canvas        = document.createElement('div');
-      canvas.className    = 'cal-piece-canvas';
-      canvas.style.cssText = [
-        'position: relative',
-        `width: ${(maxC + 1) * SQ + 4}px`,
-        `height: ${(maxR + 1) * SQ + 4}px`,
-        'min-width: 32px',
-        'min-height: 32px',
-        `outline: 2px solid ${isSel ? p.color : 'transparent'}`,
-        'border-radius: 4px',
-        'padding: 2px',
-        `cursor: ${isUsed ? 'default' : 'pointer'}`,
-        'transition: outline-color 0.15s',
+      const canvas          = document.createElement('div');
+      canvas.className      = 'cal-piece-canvas';
+      canvas.style.cssText  = [
+        'position:relative',
+        `width:${(maxC + 1) * SQ + 4}px`,
+        `height:${(maxR + 1) * SQ + 4}px`,
+        'min-width:32px',
+        'min-height:32px',
+        `outline:2px solid ${isSel ? p.color : 'transparent'}`,
+        'border-radius:4px',
+        'padding:2px',
+        `cursor:${isUsed ? 'default' : 'pointer'}`,
+        'transition:outline-color 0.15s',
       ].join(';');
 
       orient.forEach(([pr, pc]) => {
-        const sq          = document.createElement('div');
-        sq.className      = 'cal-piece-sq';
-        sq.style.cssText  = [
-          'position: absolute',
-          `left: ${pc * SQ + 2}px`,
-          `top: ${pr * SQ + 2}px`,
-          `width: ${SQ - 1}px`,
-          `height: ${SQ - 1}px`,
-          `background: ${p.color}`,
-          'border-radius: 2px',
+        const sq         = document.createElement('div');
+        sq.style.cssText = [
+          'position:absolute',
+          `left:${pc * SQ + 2}px`,
+          `top:${pr * SQ + 2}px`,
+          `width:${SQ - 1}px`,
+          `height:${SQ - 1}px`,
+          `background:${p.color}`,
+          'border-radius:2px',
         ].join(';');
         canvas.appendChild(sq);
       });
@@ -396,7 +399,7 @@
 
     const placedCellMap = getPlacedCellMap();
 
-    // Remove piece if the cell is already occupied
+    // Click an occupied cell → remove that piece and re-select it
     if (placedCellMap[k] !== undefined) {
       const pid = placedCellMap[k];
       delete placedPieces[pid];
@@ -425,12 +428,15 @@
 
   // ── Reset ─────────────────────────────────────────────────────────────────────
   function resetAll() {
-    placedPieces  = {};
-    selectedPiece = null;
-    solutions     = [];
-    solIdx        = 0;
-    mode          = 'play';
-    orientIdxs    = Array(10).fill(0);
+    abortSolver();
+    placedPieces         = {};
+    selectedPiece        = null;
+    solutions            = [];
+    solIdx               = 0;
+    mode                 = 'play';
+    orientIdxs           = Array(10).fill(0);
+    solveBtn.textContent = 'Show Solutions';
+    solveBtn.disabled    = false;
     renderPieceTray();
     renderBoard();
   }
@@ -440,18 +446,7 @@
   daySel.addEventListener('change',     e => { selDay     = e.target.value; resetAll(); });
   weekdaySel.addEventListener('change', e => { selWeekday = e.target.value; resetAll(); });
 
-  solveBtn.addEventListener('click', () => {
-    solveBtn.textContent = 'Solving…';
-    solveBtn.disabled    = true;
-    setTimeout(() => {
-      solutions = solve(selMonth, selDay, selWeekday, 50);
-      solIdx    = 0;
-      mode      = 'solution';
-      solveBtn.textContent = 'Show Solutions';
-      solveBtn.disabled    = false;
-      renderBoard();
-    }, 50);
-  });
+  solveBtn.addEventListener('click', runSolver);
 
   playModeBtn.addEventListener('click', () => {
     mode = 'play';

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,0 +1,477 @@
+(function () {
+  'use strict';
+
+  // ── Board Definition ──────────────────────────────────────────────────────────
+  const MONTHS   = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  const DAYS     = Array.from({length: 31}, (_, i) => String(i + 1));
+  const WEEKDAYS = ['Sun','Mon','Tues','Wed','Thur','Fri','Sat'];
+
+  const BOARD_CELLS = {};
+  const LABEL_TO_RC = {};
+
+  (function buildBoard() {
+    function add(r, c, lbl) {
+      BOARD_CELLS[`${r},${c}`] = lbl;
+      LABEL_TO_RC[lbl] = `${r},${c}`;
+    }
+    MONTHS.slice(0, 6).forEach((m, i) => add(0, i, m));
+    MONTHS.slice(6).forEach((m, i)    => add(1, i, m));
+    let d = 0;
+    for (let r = 2; r <= 5; r++) for (let c = 0; c < 7; c++) add(r, c, DAYS[d++]);
+    [DAYS[28], DAYS[29], DAYS[30], 'Sun', 'Mon', 'Tues', 'Wed'].forEach((lbl, c) => add(6, c, lbl));
+    ['Thur', 'Fri', 'Sat'].forEach((lbl, i) => add(7, i + 4, lbl));
+  }());
+
+  const ALL_VALID    = new Set(Object.keys(BOARD_CELLS));
+  const PERM_BLOCKED = new Set(['0,6', '1,6', '7,0', '7,1', '7,2', '7,3']);
+
+  // ── Piece Definitions ─────────────────────────────────────────────────────────
+  const PIECE_DEFS = [
+    { id: 0, color: '#e74c3c', squares: [[0,0],[0,1],[1,0],[2,0]]           },
+    { id: 1, color: '#e67e22', squares: [[0,1],[1,1],[2,0],[2,1],[2,2]]     },
+    { id: 2, color: '#d4ac0d', squares: [[0,0],[0,1],[1,1],[1,2]]           },
+    { id: 3, color: '#27ae60', squares: [[0,0],[1,0],[2,0],[3,0],[3,1]]     },
+    { id: 4, color: '#1abc9c', squares: [[0,0],[0,1],[0,2],[1,0],[1,2]]     },
+    { id: 5, color: '#3498db', squares: [[0,1],[0,2],[1,0],[1,1]]           },
+    { id: 6, color: '#9b59b6', squares: [[0,1],[1,0],[1,1],[2,0],[3,0]]     },
+    { id: 7, color: '#e91e63', squares: [[0,0],[1,0],[2,0],[3,0]]           },
+    { id: 8, color: '#00bcd4', squares: [[0,0],[1,0],[2,0],[2,1],[2,2]]     },
+    { id: 9, color: '#ff9800', squares: [[0,0],[0,1],[1,1],[2,1],[2,2]]     },
+  ];
+
+  // ── Orientation helpers ───────────────────────────────────────────────────────
+  function normalize(sqs) {
+    const minR = Math.min(...sqs.map(([r]) => r));
+    const minC = Math.min(...sqs.map(([, c]) => c));
+    return sqs.map(([r, c]) => [r - minR, c - minC]).sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  }
+  function rot90(sqs) { return normalize(sqs.map(([r, c]) => [c, -r])); }
+  function flipH(sqs) {
+    const mx = Math.max(...sqs.map(([, c]) => c));
+    return normalize(sqs.map(([r, c]) => [r, mx - c]));
+  }
+  function sqKey(sqs) { return normalize(sqs).map(s => s.join(',')).join('|'); }
+  function getAllOrientations(sqs) {
+    const seen = new Set(), res = [];
+    let cur = sqs;
+    for (let f = 0; f < 2; f++) {
+      for (let r = 0; r < 4; r++) {
+        const n = normalize(cur), k = sqKey(n);
+        if (!seen.has(k)) { seen.add(k); res.push(n); }
+        cur = rot90(cur);
+      }
+      cur = flipH(cur);
+    }
+    return res;
+  }
+  const PIECE_ORIENTATIONS = PIECE_DEFS.map(p => getAllOrientations(p.squares));
+
+  // ── Solver (backtracking) ─────────────────────────────────────────────────────
+  function solve(targetMonth, targetDay, targetWeekday, maxSols) {
+    const targetRCs = new Set(
+      [LABEL_TO_RC[targetMonth], LABEL_TO_RC[targetDay], LABEL_TO_RC[targetWeekday]].filter(Boolean)
+    );
+
+    const toFill = [];
+    for (let r = 0; r < 8; r++) {
+      for (let c = 0; c < 7; c++) {
+        const k = `${r},${c}`;
+        if (ALL_VALID.has(k) && !PERM_BLOCKED.has(k) && !targetRCs.has(k)) toFill.push(k);
+      }
+    }
+
+    const solutions = [];
+    const board     = {};
+    const used      = new Array(10).fill(false);
+    const remaining = new Set(toFill);
+
+    function bt() {
+      if (remaining.size === 0) {
+        solutions.push({ ...board });
+        return solutions.length >= maxSols;
+      }
+      const [first] = remaining;
+      const [fr, fc] = first.split(',').map(Number);
+      for (let pid = 0; pid < 10; pid++) {
+        if (used[pid]) continue;
+        for (const orient of PIECE_ORIENTATIONS[pid]) {
+          for (const [pr, pc] of orient) {
+            const dr = fr - pr, dc = fc - pc;
+            const placed = orient.map(([rr, cc]) => `${rr + dr},${cc + dc}`);
+            if (placed.every(k => remaining.has(k))) {
+              placed.forEach(k => { board[k] = pid; remaining.delete(k); });
+              used[pid] = true;
+              if (bt()) return true;
+              used[pid] = false;
+              placed.forEach(k => { delete board[k]; remaining.add(k); });
+            }
+          }
+        }
+      }
+      return false;
+    }
+    bt();
+    return solutions;
+  }
+
+  // ── State ─────────────────────────────────────────────────────────────────────
+  function getTodayLabels() {
+    const now = new Date();
+    return {
+      month:   MONTHS[now.getMonth()],
+      day:     String(now.getDate()),
+      weekday: WEEKDAYS[now.getDay()],
+    };
+  }
+
+  const today    = getTodayLabels();
+  let selMonth   = today.month;
+  let selDay     = today.day;
+  let selWeekday = today.weekday;
+  let mode          = 'play';   // 'play' | 'solution'
+  let placedPieces  = {};       // pieceId (number key) -> [{r, c}]
+  let selectedPiece = null;
+  let orientIdxs    = Array(10).fill(0);
+  let solutions     = [];
+  let solIdx        = 0;
+  let hoverCell     = null;
+
+  // ── DOM references ────────────────────────────────────────────────────────────
+  const boardEl     = document.getElementById('calBoard');
+  const winBanner   = document.getElementById('calWinBanner');
+  const noSolsEl    = document.getElementById('calNoSolutions');
+  const solveBtn    = document.getElementById('calSolve');
+  const playModeBtn = document.getElementById('calPlayMode');
+  const resetBtn    = document.getElementById('calReset');
+  const solNav      = document.getElementById('calSolutionNav');
+  const prevSolBtn  = document.getElementById('calPrevSol');
+  const nextSolBtn  = document.getElementById('calNextSol');
+  const solCount    = document.getElementById('calSolCount');
+  const pieceTray   = document.getElementById('calPieceTray');
+  const piecesGrid  = document.getElementById('calPiecesGrid');
+  const monthSel    = document.getElementById('calMonth');
+  const daySel      = document.getElementById('calDay');
+  const weekdaySel  = document.getElementById('calWeekday');
+
+  // ── Populate selects ──────────────────────────────────────────────────────────
+  function populateSelect(el, options, selected) {
+    options.forEach(o => {
+      const opt     = document.createElement('option');
+      opt.value     = o;
+      opt.textContent = o;
+      if (o === selected) opt.selected = true;
+      el.appendChild(opt);
+    });
+  }
+  populateSelect(monthSel,   MONTHS,   selMonth);
+  populateSelect(daySel,     DAYS,     selDay);
+  populateSelect(weekdaySel, WEEKDAYS, selWeekday);
+
+  // ── Derived helpers ───────────────────────────────────────────────────────────
+  function getTargetRCs() {
+    return new Set(
+      [LABEL_TO_RC[selMonth], LABEL_TO_RC[selDay], LABEL_TO_RC[selWeekday]].filter(Boolean)
+    );
+  }
+
+  function getPlacedCellMap() {
+    const map = {};
+    Object.entries(placedPieces).forEach(([pid, sqs]) => {
+      sqs.forEach(({ r, c }) => { map[`${r},${c}`] = Number(pid); });
+    });
+    return map;
+  }
+
+  function getDisplayBoard() {
+    if (mode === 'solution' && solutions.length > 0) return solutions[solIdx];
+    return getPlacedCellMap();
+  }
+
+  // ── Board rendering ───────────────────────────────────────────────────────────
+  function renderBoard() {
+    const targetRCs     = getTargetRCs();
+    const displayBoard  = getDisplayBoard();
+    const placedCellMap = getPlacedCellMap();
+    const usedIds       = new Set(Object.keys(placedPieces).map(Number));
+    const isWin         = mode === 'play' && usedIds.size === 10;
+
+    // Compute preview cells
+    const validPreview   = new Set();
+    const invalidPreview = new Set();
+    if (mode === 'play' && selectedPiece !== null && hoverCell) {
+      const [hr, hc] = hoverCell;
+      const orient   = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
+      const placed   = orient.map(([pr, pc]) => ({ r: hr + pr, c: hc + pc }));
+      const ok       = placed.every(({ r, c }) => {
+        const pk = `${r},${c}`;
+        return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedCellMap[pk] === undefined;
+      });
+      if (ok) {
+        placed.forEach(({ r, c }) => validPreview.add(`${r},${c}`));
+      } else {
+        placed.forEach(({ r, c }) => {
+          if (r >= 0 && r < 8 && c >= 0 && c < 7 && ALL_VALID.has(`${r},${c}`)) {
+            invalidPreview.add(`${r},${c}`);
+          }
+        });
+      }
+    }
+
+    // Update each cell element
+    for (let r = 0; r < 8; r++) {
+      for (let c = 0; c < 7; c++) {
+        const k    = `${r},${c}`;
+        const cell = document.getElementById(`cal-${r}-${c}`);
+        if (!cell) continue;
+
+        const labelEl   = cell.querySelector('.cal-cell-label');
+        const isBlocked = !ALL_VALID.has(k) || PERM_BLOCKED.has(k);
+
+        cell.className     = 'cal-cell';
+        cell.style.background = '';
+        cell.style.cursor  = '';
+
+        if (isBlocked) {
+          cell.classList.add('cal-cell--blocked');
+          labelEl.textContent = '';
+          continue;
+        }
+
+        const isTarget  = targetRCs.has(k);
+        const inValid   = validPreview.has(k);
+        const inInvalid = invalidPreview.has(k);
+        const pid       = displayBoard[k];
+        const lbl       = BOARD_CELLS[k] || '';
+
+        if (isTarget) {
+          cell.classList.add('cal-cell--target');
+          labelEl.textContent = lbl;
+        } else if (inValid) {
+          cell.classList.add('cal-cell--preview-valid');
+          labelEl.textContent = '';
+        } else if (inInvalid) {
+          cell.classList.add('cal-cell--preview-invalid');
+          labelEl.textContent = '';
+        } else if (pid !== undefined) {
+          cell.classList.add('cal-cell--placed');
+          cell.style.background = PIECE_DEFS[pid].color;
+          labelEl.textContent   = '';
+          if (mode === 'play') cell.style.cursor = 'pointer';
+        } else {
+          cell.classList.add('cal-cell--empty');
+          labelEl.textContent = lbl;
+          if (mode === 'play' && selectedPiece !== null) cell.style.cursor = 'crosshair';
+        }
+      }
+    }
+
+    // Banners
+    winBanner.hidden = !isWin;
+    noSolsEl.hidden  = !(mode === 'solution' && solutions.length === 0);
+
+    // Play mode button state
+    playModeBtn.classList.toggle('btn-primary', mode === 'play');
+    playModeBtn.classList.toggle('btn-outline',  mode !== 'play');
+
+    // Solution navigator
+    if (mode === 'solution' && solutions.length > 0) {
+      solNav.hidden = false;
+      const more    = solutions.length >= 50 ? ' (50+ exist)' : '';
+      solCount.textContent  = `Solution ${solIdx + 1} of ${solutions.length}${more}`;
+      prevSolBtn.disabled   = solIdx === 0;
+      nextSolBtn.disabled   = solIdx === solutions.length - 1;
+    } else {
+      solNav.hidden = true;
+    }
+
+    // Show/hide piece tray
+    pieceTray.hidden = mode !== 'play';
+  }
+
+  // ── Build board DOM (once) ────────────────────────────────────────────────────
+  function buildBoardDOM() {
+    boardEl.innerHTML = '';
+    for (let r = 0; r < 8; r++) {
+      for (let c = 0; c < 7; c++) {
+        const k    = `${r},${c}`;
+        const cell = document.createElement('div');
+        cell.id        = `cal-${r}-${c}`;
+        cell.className = 'cal-cell';
+        cell.setAttribute('role', 'gridcell');
+
+        const labelEl       = document.createElement('span');
+        labelEl.className   = 'cal-cell-label';
+        cell.appendChild(labelEl);
+
+        const isBlocked = !ALL_VALID.has(k) || PERM_BLOCKED.has(k);
+        if (!isBlocked) {
+          cell.addEventListener('click',      () => handleCellClick(r, c));
+          cell.addEventListener('mouseenter', () => { hoverCell = [r, c]; renderBoard(); });
+          cell.addEventListener('mouseleave', () => { hoverCell = null;   renderBoard(); });
+        }
+        boardEl.appendChild(cell);
+      }
+    }
+  }
+
+  // ── Piece tray rendering ──────────────────────────────────────────────────────
+  function renderPieceTray() {
+    piecesGrid.innerHTML = '';
+    const usedIds = new Set(Object.keys(placedPieces).map(Number));
+
+    PIECE_DEFS.forEach(p => {
+      const isUsed = usedIds.has(p.id);
+      const isSel  = selectedPiece === p.id;
+      const orient = PIECE_ORIENTATIONS[p.id][orientIdxs[p.id]];
+      const maxR   = Math.max(...orient.map(([r]) => r));
+      const maxC   = Math.max(...orient.map(([, c]) => c));
+      const SQ     = 14;
+
+      const wrapper       = document.createElement('div');
+      wrapper.className   = 'cal-piece-wrapper' + (isUsed ? ' cal-piece--used' : '');
+
+      const canvas        = document.createElement('div');
+      canvas.className    = 'cal-piece-canvas';
+      canvas.style.cssText = [
+        'position: relative',
+        `width: ${(maxC + 1) * SQ + 4}px`,
+        `height: ${(maxR + 1) * SQ + 4}px`,
+        'min-width: 32px',
+        'min-height: 32px',
+        `outline: 2px solid ${isSel ? p.color : 'transparent'}`,
+        'border-radius: 4px',
+        'padding: 2px',
+        `cursor: ${isUsed ? 'default' : 'pointer'}`,
+        'transition: outline-color 0.15s',
+      ].join(';');
+
+      orient.forEach(([pr, pc]) => {
+        const sq          = document.createElement('div');
+        sq.className      = 'cal-piece-sq';
+        sq.style.cssText  = [
+          'position: absolute',
+          `left: ${pc * SQ + 2}px`,
+          `top: ${pr * SQ + 2}px`,
+          `width: ${SQ - 1}px`,
+          `height: ${SQ - 1}px`,
+          `background: ${p.color}`,
+          'border-radius: 2px',
+        ].join(';');
+        canvas.appendChild(sq);
+      });
+
+      if (!isUsed) {
+        canvas.addEventListener('click', () => {
+          selectedPiece = (selectedPiece === p.id) ? null : p.id;
+          renderPieceTray();
+          renderBoard();
+        });
+      }
+
+      const rotBtn          = document.createElement('button');
+      rotBtn.className      = 'cal-rotate-btn';
+      rotBtn.textContent    = '↻ rotate';
+      rotBtn.disabled       = isUsed;
+      rotBtn.setAttribute('aria-label', `Rotate piece ${p.id + 1}`);
+      rotBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        if (isUsed) return;
+        orientIdxs[p.id] = (orientIdxs[p.id] + 1) % PIECE_ORIENTATIONS[p.id].length;
+        renderPieceTray();
+        renderBoard();
+      });
+
+      wrapper.appendChild(canvas);
+      wrapper.appendChild(rotBtn);
+      piecesGrid.appendChild(wrapper);
+    });
+  }
+
+  // ── Cell click handler ────────────────────────────────────────────────────────
+  function handleCellClick(r, c) {
+    if (mode !== 'play') return;
+    const k         = `${r},${c}`;
+    const targetRCs = getTargetRCs();
+    if (PERM_BLOCKED.has(k) || !ALL_VALID.has(k) || targetRCs.has(k)) return;
+
+    const placedCellMap = getPlacedCellMap();
+
+    // Remove piece if the cell is already occupied
+    if (placedCellMap[k] !== undefined) {
+      const pid = placedCellMap[k];
+      delete placedPieces[pid];
+      if (selectedPiece === null) selectedPiece = pid;
+      renderBoard();
+      renderPieceTray();
+      return;
+    }
+
+    if (selectedPiece === null) return;
+
+    const orient  = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
+    const placed  = orient.map(([pr, pc]) => ({ r: r + pr, c: c + pc }));
+    const isValid = placed.every(({ r: pr, c: pc }) => {
+      const pk = `${pr},${pc}`;
+      return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk) && placedCellMap[pk] === undefined;
+    });
+
+    if (isValid) {
+      placedPieces[selectedPiece] = placed;
+      selectedPiece = null;
+      renderBoard();
+      renderPieceTray();
+    }
+  }
+
+  // ── Reset ─────────────────────────────────────────────────────────────────────
+  function resetAll() {
+    placedPieces  = {};
+    selectedPiece = null;
+    solutions     = [];
+    solIdx        = 0;
+    mode          = 'play';
+    orientIdxs    = Array(10).fill(0);
+    renderPieceTray();
+    renderBoard();
+  }
+
+  // ── Event listeners ───────────────────────────────────────────────────────────
+  monthSel.addEventListener('change',   e => { selMonth   = e.target.value; resetAll(); });
+  daySel.addEventListener('change',     e => { selDay     = e.target.value; resetAll(); });
+  weekdaySel.addEventListener('change', e => { selWeekday = e.target.value; resetAll(); });
+
+  solveBtn.addEventListener('click', () => {
+    solveBtn.textContent = 'Solving…';
+    solveBtn.disabled    = true;
+    setTimeout(() => {
+      solutions = solve(selMonth, selDay, selWeekday, 50);
+      solIdx    = 0;
+      mode      = 'solution';
+      solveBtn.textContent = 'Show Solutions';
+      solveBtn.disabled    = false;
+      renderBoard();
+    }, 50);
+  });
+
+  playModeBtn.addEventListener('click', () => {
+    mode = 'play';
+    renderBoard();
+    renderPieceTray();
+  });
+
+  resetBtn.addEventListener('click', resetAll);
+
+  prevSolBtn.addEventListener('click', () => {
+    if (solIdx > 0) { solIdx--; renderBoard(); }
+  });
+
+  nextSolBtn.addEventListener('click', () => {
+    if (solIdx < solutions.length - 1) { solIdx++; renderBoard(); }
+  });
+
+  // ── Init ──────────────────────────────────────────────────────────────────────
+  buildBoardDOM();
+  renderPieceTray();
+  renderBoard();
+
+}());

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -136,9 +136,9 @@
       solveBtn.textContent = 'Show Solutions';
       solveBtn.disabled    = false;
       renderBoard();
-    }, 30000);
+    }, 120000);
 
-    solverWorker.postMessage({ month: selMonth, day: selDay, weekday: selWeekday, maxSols: 50 });
+    solverWorker.postMessage({ month: selMonth, day: selDay, weekday: selWeekday, maxSols: 500 });
   }
 
   // ── Drag & Drop ───────────────────────────────────────────────────────────────
@@ -304,7 +304,7 @@
   const noSolsEl      = document.getElementById('calNoSolutions');
   const solveBtn      = document.getElementById('calSolve');
   const resetBtn      = document.getElementById('calReset');
-  const solNav        = document.getElementById('calSolutionNav');
+  const solPanel      = document.getElementById('calSolutionPanel');
   const prevSolBtn    = document.getElementById('calPrevSol');
   const nextSolBtn    = document.getElementById('calNextSol');
   const solCount      = document.getElementById('calSolCount');
@@ -423,13 +423,13 @@
     noSolsEl.hidden  = !(mode === 'solution' && solutions.length === 0);
 
     if (mode === 'solution' && solutions.length > 0) {
-      solNav.hidden = false;
-      const more    = solutions.length >= 50 ? ' (50+ exist)' : '';
-      solCount.textContent = `Solution ${solIdx + 1} of ${solutions.length}${more}`;
+      solPanel.hidden = false;
+      const more      = solutions.length >= 500 ? '+' : ` of ${solutions.length}`;
+      solCount.textContent = `Solution ${solIdx + 1}${more}`;
       prevSolBtn.disabled  = solIdx === 0;
       nextSolBtn.disabled  = solIdx === solutions.length - 1;
     } else {
-      solNav.hidden = true;
+      solPanel.hidden = true;
     }
 
     pieceTray.hidden = mode !== 'play';

--- a/project.html
+++ b/project.html
@@ -501,20 +501,11 @@
 
         <div class="calendar-puzzle-wrapper">
 
-          <!-- Date selectors -->
-          <div class="cal-date-selectors">
-            <div class="cal-select-group">
-              <label for="calMonth">Month</label>
-              <select id="calMonth"></select>
-            </div>
-            <div class="cal-select-group">
-              <label for="calDay">Day</label>
-              <select id="calDay"></select>
-            </div>
-            <div class="cal-select-group">
-              <label for="calWeekday">Weekday</label>
-              <select id="calWeekday"></select>
-            </div>
+          <!-- Date picker -->
+          <div class="cal-date-picker-wrap">
+            <label class="cal-date-label" for="calDateInput">Date</label>
+            <input type="date" id="calDateInput" class="cal-date-input">
+            <div class="cal-date-display" id="calDateDisplay"></div>
           </div>
 
           <!-- Board -->
@@ -529,20 +520,20 @@
           <!-- Controls -->
           <div class="cal-controls">
             <button class="btn btn-outline" id="calSolve">&#128269; Show Solutions</button>
-            <button class="btn btn-primary" id="calPlayMode">&#9998; Play Mode</button>
             <button class="btn btn-outline" id="calReset">&#8635; Reset</button>
           </div>
 
-          <!-- Solution navigator -->
+          <!-- Solution navigator (shown only in solution mode) -->
           <div class="cal-solution-nav" id="calSolutionNav" hidden>
-            <button id="calPrevSol" aria-label="Previous solution">&#8249;</button>
-            <span id="calSolCount">Solution 1 of 5</span>
-            <button id="calNextSol" aria-label="Next solution">&#8250;</button>
+            <button class="cal-sol-arrow" id="calPrevSol" aria-label="Previous solution">&#8249;</button>
+            <span class="cal-sol-count" id="calSolCount">Solution 1 of 5</span>
+            <button class="cal-sol-arrow" id="calNextSol" aria-label="Next solution">&#8250;</button>
+            <button class="cal-back-play-btn" id="calBackToPlay">&#8592; Play</button>
           </div>
 
           <!-- Piece tray -->
           <div class="cal-piece-tray" id="calPieceTray">
-            <p class="cal-piece-tray-label">Select a piece &rarr; click board to place &middot; click placed piece to remove</p>
+            <p class="cal-piece-tray-label">Drag a piece onto the board &middot; or click to select, then click the board to place &middot; drag or click placed pieces to move them</p>
             <div class="cal-pieces-grid" id="calPiecesGrid"></div>
           </div>
 

--- a/project.html
+++ b/project.html
@@ -75,6 +75,7 @@
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/tictactoe.css">
   <link rel="stylesheet" href="css/connect.css">
+  <link rel="stylesheet" href="css/calendar.css">
 
   <!-- @@analytics:start -->
   <link rel="preconnect" href="https://www.googletagmanager.com">
@@ -483,6 +484,88 @@
       </div>
     </section>
 
+    <!-- ── Calendar Puzzle ── -->
+    <section class="section" id="calendar-puzzle" aria-label="Calendar Puzzle">
+      <div class="container">
+        <div class="section-header">
+          <p class="section-label">Personal Project</p>
+          <h2 class="section-title">Calendar Puzzle</h2>
+          <div class="section-divider"></div>
+        </div>
+
+        <div class="projects-section-intro">
+          <p>
+            A daily puzzle: cover every cell on the board except today's month, day, and weekday using ten uniquely shaped pieces. Each date has multiple solutions &mdash; find one yourself or let the solver reveal them.
+          </p>
+        </div>
+
+        <div class="calendar-puzzle-wrapper">
+
+          <!-- Date selectors -->
+          <div class="cal-date-selectors">
+            <div class="cal-select-group">
+              <label for="calMonth">Month</label>
+              <select id="calMonth"></select>
+            </div>
+            <div class="cal-select-group">
+              <label for="calDay">Day</label>
+              <select id="calDay"></select>
+            </div>
+            <div class="cal-select-group">
+              <label for="calWeekday">Weekday</label>
+              <select id="calWeekday"></select>
+            </div>
+          </div>
+
+          <!-- Board -->
+          <div class="cal-board" id="calBoard" role="grid" aria-label="Calendar puzzle board"></div>
+
+          <!-- Win banner -->
+          <div class="cal-win-banner" id="calWinBanner" hidden>&#x1F389; Puzzle Solved!</div>
+
+          <!-- No solutions message -->
+          <div class="cal-no-solutions" id="calNoSolutions" hidden>No solutions found for this combination.</div>
+
+          <!-- Controls -->
+          <div class="cal-controls">
+            <button class="btn btn-outline" id="calSolve">&#128269; Show Solutions</button>
+            <button class="btn btn-primary" id="calPlayMode">&#9998; Play Mode</button>
+            <button class="btn btn-outline" id="calReset">&#8635; Reset</button>
+          </div>
+
+          <!-- Solution navigator -->
+          <div class="cal-solution-nav" id="calSolutionNav" hidden>
+            <button id="calPrevSol" aria-label="Previous solution">&#8249;</button>
+            <span id="calSolCount">Solution 1 of 5</span>
+            <button id="calNextSol" aria-label="Next solution">&#8250;</button>
+          </div>
+
+          <!-- Piece tray -->
+          <div class="cal-piece-tray" id="calPieceTray">
+            <p class="cal-piece-tray-label">Select a piece &rarr; click board to place &middot; click placed piece to remove</p>
+            <div class="cal-pieces-grid" id="calPiecesGrid"></div>
+          </div>
+
+          <!-- Legend -->
+          <div class="cal-legend">
+            <div class="cal-legend-item">
+              <div class="cal-legend-swatch" style="background:#fff9c4;border:2px solid #f9a825"></div>
+              <span>Today&rsquo;s date</span>
+            </div>
+            <div class="cal-legend-item">
+              <div class="cal-legend-swatch cal-legend-swatch--empty"></div>
+              <span>Empty cell</span>
+            </div>
+            <div class="cal-legend-item">
+              <div class="cal-legend-swatch cal-legend-swatch--blocked"></div>
+              <span>Blocked</span>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
   </main>
 
   <!-- @@footer:start -->
@@ -517,6 +600,7 @@
 
   <script src="js/project.js" defer></script>
   <script src="js/connect.js" defer></script>
+  <script src="js/calendar.js" defer></script>
   <!-- @@scripts-common:start -->
   <script src="js/theme.js" defer></script>
   <script src="js/main.js" defer></script>

--- a/project.html
+++ b/project.html
@@ -523,33 +523,22 @@
             <button class="btn btn-outline" id="calReset">&#8635; Reset</button>
           </div>
 
-          <!-- Solution navigator (shown only in solution mode) -->
-          <div class="cal-solution-nav" id="calSolutionNav" hidden>
-            <button class="cal-sol-arrow" id="calPrevSol" aria-label="Previous solution">&#8249;</button>
-            <span class="cal-sol-count" id="calSolCount">Solution 1 of 5</span>
-            <button class="cal-sol-arrow" id="calNextSol" aria-label="Next solution">&#8250;</button>
-            <button class="cal-back-play-btn" id="calBackToPlay">&#8592; Play</button>
-          </div>
-
-          <!-- Piece tray -->
+          <!-- Piece tray (play mode) -->
           <div class="cal-piece-tray" id="calPieceTray">
             <p class="cal-piece-tray-label">Drag a piece onto the board &middot; or click to select, then click the board to place &middot; drag or click placed pieces to move them</p>
             <div class="cal-pieces-grid" id="calPiecesGrid"></div>
           </div>
 
-          <!-- Legend -->
-          <div class="cal-legend">
-            <div class="cal-legend-item">
-              <div class="cal-legend-swatch" style="background:#fff9c4;border:2px solid #f9a825"></div>
-              <span>Today&rsquo;s date</span>
+          <!-- Solution Panel (shown only when solutions are found) -->
+          <div class="cal-solution-panel" id="calSolutionPanel" hidden>
+            <div class="cal-solution-panel-header">
+              <span class="cal-solution-panel-title">Solution Viewer</span>
+              <button class="cal-solution-back-btn" id="calBackToPlay">&#8592; Back to Playing</button>
             </div>
-            <div class="cal-legend-item">
-              <div class="cal-legend-swatch cal-legend-swatch--empty"></div>
-              <span>Empty cell</span>
-            </div>
-            <div class="cal-legend-item">
-              <div class="cal-legend-swatch cal-legend-swatch--blocked"></div>
-              <span>Blocked</span>
+            <div class="cal-solution-panel-nav">
+              <button class="cal-sol-arrow" id="calPrevSol" aria-label="Previous solution">&#8249;</button>
+              <span class="cal-sol-count" id="calSolCount">Solution 1 of 5</span>
+              <button class="cal-sol-arrow" id="calNextSol" aria-label="Next solution">&#8250;</button>
             </div>
           </div>
 

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'dm-v1';
+const CACHE = 'dm-v2';
 
 const ASSETS = [
   '/',
@@ -10,10 +10,12 @@ const ASSETS = [
   '/css/main.css',
   '/css/tictactoe.css',
   '/css/connect.css',
+  '/css/calendar.css',
   '/js/main.js',
   '/js/theme.js',
   '/js/project.js',
   '/js/connect.js',
+  '/js/calendar.js',
   '/fonts/inter-latin.woff2',
   '/fonts/poppins-600.woff2',
   '/fonts/poppins-700.woff2',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'dm-v3';
+const CACHE = 'dm-v4';
 
 const ASSETS = [
   '/',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'dm-v2';
+const CACHE = 'dm-v3';
 
 const ASSETS = [
   '/',
@@ -16,6 +16,7 @@ const ASSETS = [
   '/js/project.js',
   '/js/connect.js',
   '/js/calendar.js',
+  '/js/calendar-worker.js',
   '/fonts/inter-latin.woff2',
   '/fonts/poppins-600.woff2',
   '/fonts/poppins-700.woff2',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'dm-v4';
+const CACHE = 'dm-v5';
 
 const ASSETS = [
   '/',


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new **Calendar Puzzle** section to the Projects page as a standalone interactive game
- Players cover every board cell except today's month, day, and weekday using 10 uniquely shaped pieces
- Includes a backtracking solver that finds and navigates up to 50 solutions per date

## What's included

**`js/calendar.js`** — Full game engine:
- 7×8 board built from months (Jan–Dec), days (1–31), and weekdays (Sun–Sat)
- 10 piece definitions (tetrominoes + pentominoes) with rotation/flip orientation generation
- Backtracking solver returning up to 50 solutions per date combination
- Play mode: select piece → hover preview (blue=valid, red=invalid) → click to place; click placed piece to remove it
- Solution mode: displays solver output with prev/next navigator
- Win banner when all 10 pieces are placed; board auto-resets when date changes

**`css/calendar.css`** — Scoped styles:
- Responsive board (50px cells → 42px → 35px on small screens)
- Dark mode support via existing `[data-theme="dark"]` CSS variables
- Piece tray, solution navigator, win/no-solution banners

**`project.html`** — New section added after "How the AI Works", with CSS + JS links

**`sw.js`** — Cache version bumped to `dm-v2`, new files added to asset list

## Test plan

- [ ] Board renders correctly for today's date with month/day/weekday highlighted in amber
- [ ] Selecting a piece and hovering shows blue preview; hovering over an invalid position shows red
- [ ] Placing a piece fills cells with the piece color; clicking a placed piece removes it
- [ ] Rotating a piece changes its orientation in the tray and in the hover preview
- [ ] "Show Solutions" runs the solver and displays the first solution; prev/next navigator works
- [ ] "Play Mode" button switches back from solution view; "Reset" clears all pieces
- [ ] Changing the date selectors resets the board and highlights the new target cells
- [ ] Dark mode renders correctly (amber target cells, dark empty cells)
- [ ] Board scales down on mobile without overflow

https://claude.ai/code/session_01DNQ5eVnuRqyGTMMf6kzAS3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNQ5eVnuRqyGTMMf6kzAS3)_