### PR TITLE
Improve calendar puzzle: layout, UX, and solver speed

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -180,8 +180,8 @@
 
 /* ── Solution Panel ──────────────────────────────────────────────────────── */
 .cal-solution-panel {
-  background: var(--navy);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
   border-radius: 14px;
   padding: 16px 20px;
   width: 100%;
@@ -204,7 +204,7 @@
   text-transform: uppercase;
   letter-spacing: 0.1em;
   font-weight: 700;
-  color: #94a3b8;
+  color: var(--text-muted);
 }
 
 .cal-solution-panel-nav {
@@ -237,16 +237,16 @@
 
 .cal-sol-count {
   font-weight: 600;
-  color: #ffffff;
+  color: var(--text);
   font-size: 0.9rem;
   min-width: 150px;
   text-align: center;
 }
 
 .cal-solution-back-btn {
-  background: rgba(255, 255, 255, 0.07);
-  color: #94a3b8;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 5px 12px;
   font-size: 0.78rem;
@@ -256,8 +256,8 @@
 }
 
 .cal-solution-back-btn:hover {
-  color: #ffffff;
-  background: rgba(255, 255, 255, 0.14);
+  color: var(--text);
+  background: var(--bg-card);
 }
 
 /* ── Piece tray ──────────────────────────────────────────────────────────── */

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -1,12 +1,27 @@
 /* ── Calendar Puzzle ─────────────────────────────────────────────────────── */
 
 .calendar-puzzle-wrapper {
-  max-width: 640px;
+  max-width: 900px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 20px;
+}
+
+/* ── Game layout: side-by-side piece tray + board ────────────────────────── */
+.cal-game-layout {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.cal-board-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
 }
 
 /* ── Date picker ─────────────────────────────────────────────────────────── */
@@ -121,6 +136,12 @@
   border: 2px dashed #dc2626 !important;
 }
 
+.cal-cell--conflict {
+  background: #dc2626 !important;
+  border: 2px solid #991b1b !important;
+  cursor: grab;
+}
+
 /* ── Win / no-solution banners ───────────────────────────────────────────── */
 .cal-win-banner {
   background: #16a34a;
@@ -162,14 +183,13 @@
   background: var(--navy);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 14px;
-  padding: 20px 28px;
+  padding: 16px 20px;
   width: 100%;
-  max-width: 560px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
 }
 
 .cal-solution-panel-header {
@@ -245,26 +265,27 @@
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 12px;
-  padding: 16px 16px 12px;
-  width: 100%;
-  max-width: 560px;
+  padding: 12px 10px;
   box-sizing: border-box;
+  /* Side panel: fixed width, scrolls if needed */
+  width: 140px;
+  flex-shrink: 0;
 }
 
 .cal-piece-tray-label {
-  font-size: 0.68rem;
+  font-size: 0.62rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--blue);
   text-align: center;
-  margin-bottom: 14px;
+  margin-bottom: 10px;
   font-weight: 600;
 }
 
 .cal-pieces-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 14px;
+  gap: 10px;
   justify-content: center;
 }
 
@@ -324,6 +345,24 @@
 }
 
 /* ── Responsive ──────────────────────────────────────────────────────────── */
+
+/* Tablet and below: stack piece tray below board */
+@media (max-width: 700px) {
+  .cal-game-layout {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .cal-piece-tray {
+    width: 100%;
+    max-width: 400px;
+  }
+
+  .cal-pieces-grid {
+    gap: 12px;
+  }
+}
+
 @media (max-width: 520px) {
   .cal-board {
     --cal-cell: 42px;

--- a/js/calendar-worker.js
+++ b/js/calendar-worker.js
@@ -27,18 +27,17 @@ var ALL_VALID    = (function() { var s = new Set(); Object.keys(BOARD_CELLS).for
 var PERM_BLOCKED = new Set(['0,6','1,6','7,0','7,1','7,2','7,3']);
 
 // ── Piece Squares ─────────────────────────────────────────────────────────────
-// 10 pieces totalling 47 squares to fill 47 board cells (50 valid − 3 date targets)
 var PIECE_SQUARES = [
-  [[0,0],[0,1],[1,0],[2,0]],           // 0: L-tetromino        (4 sq)
-  [[0,1],[1,1],[2,0],[2,1],[2,2]],     // 1: T-pentomino        (5 sq)
-  [[0,0],[0,1],[1,1],[1,2]],           // 2: S-tetromino        (4 sq)
-  [[0,0],[1,0],[2,0],[3,0],[3,1]],     // 3: L-pentomino        (5 sq)
-  [[0,0],[0,1],[0,2],[1,0],[1,2]],     // 4: U-pentomino        (5 sq)
-  [[0,0],[0,1],[1,0],[1,1],[2,0]],     // 5: P-pentomino        (5 sq) — 2×2 box + extra
-  [[0,1],[1,0],[1,1],[2,0],[3,0]],     // 6: skew-pentomino     (5 sq)
-  [[0,0],[1,0],[2,0],[3,0]],           // 7: I-tetromino        (4 sq)
-  [[0,0],[1,0],[2,0],[2,1],[2,2]],     // 8: J-pentomino        (5 sq)
-  [[0,0],[0,1],[1,1],[2,1],[2,2]],     // 9: S-pentomino        (5 sq)
+  [[0,0],[0,1],[1,0],[2,0]],           // 0: L-tetromino
+  [[0,1],[1,1],[2,0],[2,1],[2,2]],     // 1: T-pentomino
+  [[0,0],[0,1],[1,1],[1,2]],           // 2: S-tetromino
+  [[0,0],[1,0],[2,0],[3,0],[3,1]],     // 3: L-pentomino
+  [[0,0],[0,1],[0,2],[1,0],[1,2]],     // 4: U-pentomino
+  [[0,0],[0,1],[1,0],[1,1],[2,0]],     // 5: P-pentomino
+  [[0,1],[1,0],[1,1],[2,0],[3,0]],     // 6: skew-pentomino
+  [[0,0],[1,0],[2,0],[3,0]],           // 7: I-tetromino
+  [[0,0],[1,0],[2,0],[2,1],[2,2]],     // 8: J-pentomino
+  [[0,0],[0,1],[1,1],[2,1],[2,2]],     // 9: S-pentomino
 ];
 
 // ── Orientation helpers ───────────────────────────────────────────────────────
@@ -66,7 +65,7 @@ function getAllOrientations(sqs) {
 var PIECE_ORIENTATIONS = PIECE_SQUARES.map(getAllOrientations);
 
 // ── Solver ────────────────────────────────────────────────────────────────────
-function solve(targetMonth, targetDay, targetWeekday, maxSols) {
+function solve(targetMonth, targetDay, targetWeekday, maxSols, onSolution) {
   var targetRCs = new Set();
   [LABEL_TO_RC[targetMonth], LABEL_TO_RC[targetDay], LABEL_TO_RC[targetWeekday]].forEach(function(v) { if (v) targetRCs.add(v); });
 
@@ -78,18 +77,18 @@ function solve(targetMonth, targetDay, targetWeekday, maxSols) {
     }
   }
 
-  var solutions = [];
+  var count     = 0;
   var board     = {};
   var used      = [false,false,false,false,false,false,false,false,false,false];
   var remaining = new Set(toFill);
 
   function bt() {
     if (remaining.size === 0) {
-      solutions.push(Object.assign({}, board));
-      return solutions.length >= maxSols;
+      onSolution(Object.assign({}, board));
+      count++;
+      return count >= maxSols;
     }
 
-    // Always fill the first remaining cell — minimises branching factor
     var first = remaining.values().next().value;
     var parts = first.split(',');
     var fr = parseInt(parts[0], 10), fc = parseInt(parts[1], 10);
@@ -121,16 +120,20 @@ function solve(targetMonth, targetDay, targetWeekday, maxSols) {
   }
 
   bt();
-  return solutions;
+  return count;
 }
 
 // ── Message handler ───────────────────────────────────────────────────────────
 self.onmessage = function(e) {
   var d = e.data;
+  var maxSols = d.maxSols || 100;
   try {
-    var solutions = solve(d.month, d.day, d.weekday, d.maxSols || 50);
-    self.postMessage({ ok: true, solutions: solutions });
+    var count = solve(d.month, d.day, d.weekday, maxSols, function(sol) {
+      // Stream each solution to the main thread as found
+      self.postMessage({ type: 'solution', solution: sol });
+    });
+    self.postMessage({ type: 'done', count: count });
   } catch (err) {
-    self.postMessage({ ok: false, error: String(err) });
+    self.postMessage({ type: 'error', error: String(err) });
   }
 };

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -86,10 +86,12 @@
   let currentDate = now;
   let { month: selMonth, day: selDay, weekday: selWeekday } = labelsFromDate(now);
 
-  let mode         = 'play';   // 'play' | 'solution'
-  let placedPieces = {};       // pieceId (number) -> [{r, c}]
+  let mode          = 'play';   // 'play' | 'solution'
+  let placedPieces  = {};       // pieceId (number) -> [{r, c}]
   let selectedPiece = null;
-  let orientIdxs   = Array(10).fill(0);
+  let selectedAnchorR = 0;     // which square of the selected piece sits under the cursor
+  let selectedAnchorC = 0;
+  let orientIdxs    = Array(10).fill(0);
   let solutions    = [];
   let solIdx       = 0;
   let hoverCell    = null;     // [baseR, baseC] where orient[0,0] lands for preview
@@ -300,12 +302,20 @@
         // Click on placed piece — pick it up; suppress the click event that follows
         suppressBoardClick = true;
         delete placedPieces[pd.pieceId];
-        selectedPiece = pd.pieceId;
+        selectedPiece   = pd.pieceId;
+        selectedAnchorR = pd.anchorR;
+        selectedAnchorC = pd.anchorC;
         renderPieceTray();
         renderBoard();
       } else {
-        // Click on tray piece — toggle selection
-        selectedPiece = (selectedPiece === pd.pieceId) ? null : pd.pieceId;
+        // Click on tray piece — toggle selection; store the clicked square as anchor
+        if (selectedPiece === pd.pieceId) {
+          selectedPiece = null;
+        } else {
+          selectedPiece   = pd.pieceId;
+          selectedAnchorR = pd.anchorR;
+          selectedAnchorC = pd.anchorC;
+        }
         renderPieceTray();
         renderBoard();
       }
@@ -343,11 +353,19 @@
       pendingDrag = null;
       if (pd.fromBoard) {
         delete placedPieces[pd.pieceId];
-        selectedPiece = pd.pieceId;
+        selectedPiece   = pd.pieceId;
+        selectedAnchorR = pd.anchorR;
+        selectedAnchorC = pd.anchorC;
         renderPieceTray();
         renderBoard();
       } else {
-        selectedPiece = (selectedPiece === pd.pieceId) ? null : pd.pieceId;
+        if (selectedPiece === pd.pieceId) {
+          selectedPiece = null;
+        } else {
+          selectedPiece   = pd.pieceId;
+          selectedAnchorR = pd.anchorR;
+          selectedAnchorC = pd.anchorC;
+        }
         renderPieceTray();
         renderBoard();
       }
@@ -371,11 +389,13 @@
       if (e.key === 'ArrowRight' || e.key === 'ArrowUp' || e.key === 'r' || e.key === 'R') {
         e.preventDefault();
         orientIdxs[selectedPiece] = (orientIdxs[selectedPiece] + 1) % len;
+        selectedAnchorR = 0; selectedAnchorC = 0;
         renderPieceTray();
         renderBoard();
       } else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
         e.preventDefault();
         orientIdxs[selectedPiece] = (orientIdxs[selectedPiece] - 1 + len) % len;
+        selectedAnchorR = 0; selectedAnchorC = 0;
         renderPieceTray();
         renderBoard();
       }
@@ -526,8 +546,8 @@
 
     if (mode === 'solution' && solutions.length > 0) {
       solPanel.hidden = false;
-      const more      = solutions.length >= 100 ? '+' : ` of ${solutions.length}`;
-      solCount.textContent = `Solution ${solIdx + 1}${more}`;
+      const total     = solutions.length >= 100 ? '100+' : String(solutions.length);
+      solCount.textContent = `Solution ${solIdx + 1} of ${total}`;
       prevSolBtn.disabled  = solIdx === 0;
       nextSolBtn.disabled  = solIdx === solutions.length - 1;
     } else {
@@ -556,7 +576,7 @@
         if (!isBlocked) {
           cell.addEventListener('mouseenter', () => {
             if (drag.active) return; // drag handles its own hover
-            hoverCell = selectedPiece !== null ? [r, c] : null;
+            hoverCell = selectedPiece !== null ? [r - selectedAnchorR, c - selectedAnchorC] : null;
             renderBoard();
           });
           cell.addEventListener('mouseleave', () => {
@@ -679,6 +699,7 @@
         e.stopPropagation();
         if (isUsed || drag.active || pendingDrag) return;
         orientIdxs[p.id] = (orientIdxs[p.id] + 1) % PIECE_ORIENTATIONS[p.id].length;
+        if (selectedPiece === p.id) { selectedAnchorR = 0; selectedAnchorC = 0; }
         renderPieceTray();
         renderBoard();
       });
@@ -701,8 +722,10 @@
 
     // Piece selected — place it (overlapping allowed, conflicts shown in red)
     if (selectedPiece !== null) {
-      const orient = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
-      const placed = orient.map(([pr, pc]) => ({ r: r + pr, c: c + pc }));
+      const orient  = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
+      const baseR   = r - selectedAnchorR;
+      const baseC   = c - selectedAnchorC;
+      const placed  = orient.map(([pr, pc]) => ({ r: baseR + pr, c: baseC + pc }));
       const isValid = placed.every(({ r: pr, c: pc }) => {
         const pk = `${pr},${pc}`;
         return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk);
@@ -732,6 +755,8 @@
     if (drag.active) endDrag();
     placedPieces         = {};
     selectedPiece        = null;
+    selectedAnchorR      = 0;
+    selectedAnchorC      = 0;
     solutions            = [];
     solIdx               = 0;
     mode                 = 'play';

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -105,24 +105,33 @@
 
   function runSolver() {
     abortSolver();
-    solveBtn.textContent = 'Solving…';
+    solutions = [];
+    solIdx    = 0;
+    solveBtn.textContent = 'Searching…';
     solveBtn.disabled    = true;
 
     solverWorker = new Worker('js/calendar-worker.js');
     solverWorker.onmessage = function (e) {
-      abortSolver();
-      solutions = e.data.ok ? e.data.solutions : [];
-      solIdx    = 0;
-      mode      = 'solution';
-      solveBtn.textContent = 'Show Solutions';
-      solveBtn.disabled    = false;
-      renderBoard();
+      var msg = e.data;
+      if (msg.type === 'solution') {
+        solutions.push(msg.solution);
+        if (solutions.length === 1) {
+          // Show first solution immediately without waiting for rest
+          mode = 'solution';
+          solveBtn.textContent = 'Finding more…';
+        }
+        renderBoard();
+      } else if (msg.type === 'done' || msg.type === 'error') {
+        abortSolver();
+        if (solutions.length === 0) mode = 'solution';
+        solveBtn.textContent = 'Show Solutions';
+        solveBtn.disabled    = false;
+        renderBoard();
+      }
     };
     solverWorker.onerror = function () {
       abortSolver();
-      solutions = [];
-      solIdx    = 0;
-      mode      = 'solution';
+      mode = 'solution';
       solveBtn.textContent = 'Show Solutions';
       solveBtn.disabled    = false;
       renderBoard();
@@ -130,15 +139,13 @@
     // Safety timeout
     solverTimeout = setTimeout(function () {
       abortSolver();
-      solutions = [];
-      solIdx    = 0;
-      mode      = 'solution';
+      if (solutions.length === 0) mode = 'solution';
       solveBtn.textContent = 'Show Solutions';
       solveBtn.disabled    = false;
       renderBoard();
-    }, 120000);
+    }, 60000);
 
-    solverWorker.postMessage({ month: selMonth, day: selDay, weekday: selWeekday, maxSols: 500 });
+    solverWorker.postMessage({ month: selMonth, day: selDay, weekday: selWeekday, maxSols: 100 });
   }
 
   // ── Drag & Drop ───────────────────────────────────────────────────────────────
@@ -149,6 +156,11 @@
     anchorC:  0,
     ghostEl:  null,
   };
+
+  // Pending drag: tracks a mousedown/touchstart that hasn't moved far enough yet
+  let pendingDrag = null; // { pieceId, anchorR, anchorC, startX, startY }
+  // Suppress the cell click event that fires right after a pendingDrag mouseup pick-up
+  let suppressBoardClick = false;
 
   function getCellSize() {
     return parseInt(getComputedStyle(boardEl).getPropertyValue('--cal-cell'), 10) || 50;
@@ -242,17 +254,12 @@
         const placedMap = getPlacedCellMap();
         const orient       = PIECE_ORIENTATIONS[drag.pieceId][orientIdxs[drag.pieceId]];
         const placed       = orient.map(([pr, pc]) => ({ r: baseR + pr, c: baseC + pc }));
-        const conflictPids = new Set();
-        placed.forEach(({ r, c }) => {
-          const pid = placedMap[`${r},${c}`];
-          if (pid !== undefined) conflictPids.add(pid);
-        });
         const isValid = placed.every(({ r, c }) => {
           const pk = `${r},${c}`;
           return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk);
         });
+        // Allow overlapping — pieces placed on top of others show as red conflicts
         if (isValid) {
-          conflictPids.forEach(cid => { delete placedPieces[cid]; });
           placedPieces[drag.pieceId] = placed;
         }
       }
@@ -268,6 +275,16 @@
 
   // Mouse drag events
   document.addEventListener('mousemove', e => {
+    if (pendingDrag) {
+      const dx = Math.abs(e.clientX - pendingDrag.startX);
+      const dy = Math.abs(e.clientY - pendingDrag.startY);
+      if (dx > 5 || dy > 5) {
+        const pd = pendingDrag;
+        pendingDrag = null;
+        startDrag(pd.pieceId, pd.anchorR, pd.anchorC, e.clientX, e.clientY);
+      }
+      return;
+    }
     if (!drag.active) return;
     moveGhost(e.clientX, e.clientY);
     const cell = getBoardCellAt(e.clientX, e.clientY);
@@ -276,11 +293,41 @@
   });
 
   document.addEventListener('mouseup', e => {
+    if (pendingDrag) {
+      const pd = pendingDrag;
+      pendingDrag = null;
+      if (pd.fromBoard) {
+        // Click on placed piece — pick it up; suppress the click event that follows
+        suppressBoardClick = true;
+        delete placedPieces[pd.pieceId];
+        selectedPiece = pd.pieceId;
+        renderPieceTray();
+        renderBoard();
+      } else {
+        // Click on tray piece — toggle selection
+        selectedPiece = (selectedPiece === pd.pieceId) ? null : pd.pieceId;
+        renderPieceTray();
+        renderBoard();
+      }
+      return;
+    }
     if (drag.active) endDrag(e.clientX, e.clientY);
   });
 
   // Touch drag events
   document.addEventListener('touchmove', e => {
+    if (pendingDrag) {
+      const t  = e.touches[0];
+      const dx = Math.abs(t.clientX - pendingDrag.startX);
+      const dy = Math.abs(t.clientY - pendingDrag.startY);
+      if (dx > 5 || dy > 5) {
+        e.preventDefault();
+        const pd = pendingDrag;
+        pendingDrag = null;
+        startDrag(pd.pieceId, pd.anchorR, pd.anchorC, t.clientX, t.clientY);
+      }
+      return;
+    }
     if (!drag.active) return;
     e.preventDefault();
     const t = e.touches[0];
@@ -291,6 +338,21 @@
   }, { passive: false });
 
   document.addEventListener('touchend', e => {
+    if (pendingDrag) {
+      const pd = pendingDrag;
+      pendingDrag = null;
+      if (pd.fromBoard) {
+        delete placedPieces[pd.pieceId];
+        selectedPiece = pd.pieceId;
+        renderPieceTray();
+        renderBoard();
+      } else {
+        selectedPiece = (selectedPiece === pd.pieceId) ? null : pd.pieceId;
+        renderPieceTray();
+        renderBoard();
+      }
+      return;
+    }
     if (!drag.active) return;
     const t = e.changedTouches[0];
     endDrag(t.clientX, t.clientY);
@@ -299,6 +361,7 @@
   // Escape cancels drag or deselects; arrow keys / R rotate selected piece
   document.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
+      if (pendingDrag) { pendingDrag = null; return; }
       if (drag.active) { endDrag(); }
       else { selectedPiece = null; renderBoard(); renderPieceTray(); }
       return;
@@ -364,6 +427,19 @@
     return map;
   }
 
+  function getConflictCells() {
+    const counts = {};
+    Object.values(placedPieces).forEach(sqs => {
+      sqs.forEach(({ r, c }) => {
+        const k = `${r},${c}`;
+        counts[k] = (counts[k] || 0) + 1;
+      });
+    });
+    const conflicts = new Set();
+    Object.entries(counts).forEach(([k, n]) => { if (n > 1) conflicts.add(k); });
+    return conflicts;
+  }
+
   function getDisplayBoard() {
     if (mode === 'solution' && solutions.length > 0) return solutions[solIdx];
     return getPlacedCellMap();
@@ -374,8 +450,9 @@
     const targetRCs    = getTargetRCs();
     const displayBoard = getDisplayBoard();
     const placedMap    = getPlacedCellMap();
+    const conflictCells = mode === 'play' ? getConflictCells() : new Set();
     const usedIds      = new Set(Object.keys(placedPieces).map(Number));
-    const isWin        = mode === 'play' && usedIds.size === 10;
+    const isWin        = mode === 'play' && usedIds.size === 10 && conflictCells.size === 0;
 
     // Placement preview (works for both click-select and drag)
     const validPrev   = new Set();
@@ -427,6 +504,10 @@
         } else if (inInvalid) {
           cell.classList.add('cal-cell--preview-invalid');
           lbl.textContent = '';
+        } else if (conflictCells.has(k)) {
+          cell.classList.add('cal-cell--conflict');
+          lbl.textContent = '';
+          cell.style.cursor = 'grab';
         } else if (pid !== undefined) {
           cell.classList.add('cal-cell--placed');
           cell.style.background = PIECE_DEFS[pid].color;
@@ -445,7 +526,7 @@
 
     if (mode === 'solution' && solutions.length > 0) {
       solPanel.hidden = false;
-      const more      = solutions.length >= 500 ? '+' : ` of ${solutions.length}`;
+      const more      = solutions.length >= 100 ? '+' : ` of ${solutions.length}`;
       solCount.textContent = `Solution ${solIdx + 1}${more}`;
       prevSolBtn.disabled  = solIdx === 0;
       nextSolBtn.disabled  = solIdx === solutions.length - 1;
@@ -484,18 +565,17 @@
             renderBoard();
           });
           cell.addEventListener('click', () => handleCellClick(r, c));
-          // Board pieces can be dragged off the board
+          // Board pieces: set pendingDrag on mousedown; actual drag starts after movement threshold
           cell.addEventListener('mousedown', e => {
             if (mode !== 'play') return;
             const pid = getPlacedCellMap()[`${r},${c}`];
             if (pid === undefined) return;
             e.preventDefault();
-            // Compute anchor: which square of the orient is at (r,c)?
             const orient = PIECE_ORIENTATIONS[pid][orientIdxs[pid]];
             const base0  = placedPieces[pid][0];
             const baseR  = base0.r - orient[0][0];
             const baseC  = base0.c - orient[0][1];
-            startDrag(pid, r - baseR, c - baseC, e.clientX, e.clientY);
+            pendingDrag = { pieceId: pid, anchorR: r - baseR, anchorC: c - baseC, startX: e.clientX, startY: e.clientY, fromBoard: true };
           });
           cell.addEventListener('touchstart', e => {
             if (mode !== 'play') return;
@@ -507,7 +587,7 @@
             const base0  = placedPieces[pid][0];
             const baseR  = base0.r - orient[0][0];
             const baseC  = base0.c - orient[0][1];
-            startDrag(pid, r - baseR, c - baseC, t.clientX, t.clientY);
+            pendingDrag = { pieceId: pid, anchorR: r - baseR, anchorC: c - baseC, startX: t.clientX, startY: t.clientY, fromBoard: true };
           }, { passive: false });
         }
         boardEl.appendChild(cell);
@@ -562,16 +642,8 @@
         canvas.appendChild(sq);
       });
 
-      // Click to select (alternative to drag)
+      // Mousedown/touchstart: set pendingDrag — actual drag starts after movement threshold
       if (!isUsed) {
-        canvas.addEventListener('click', e => {
-          if (drag.active) return;
-          selectedPiece = (selectedPiece === p.id) ? null : p.id;
-          renderPieceTray();
-          renderBoard();
-        });
-
-        // Drag from tray
         canvas.addEventListener('mousedown', e => {
           if (mode !== 'play') return;
           e.preventDefault();
@@ -579,7 +651,7 @@
           const mx   = e.clientX - rect.left - 2;
           const my   = e.clientY - rect.top  - 2;
           const anchorSq = findClosestSquare(orient, Math.floor(my / SQ), Math.floor(mx / SQ));
-          startDrag(p.id, anchorSq[0], anchorSq[1], e.clientX, e.clientY);
+          pendingDrag = { pieceId: p.id, anchorR: anchorSq[0], anchorC: anchorSq[1], startX: e.clientX, startY: e.clientY };
         });
 
         canvas.addEventListener('touchstart', e => {
@@ -590,7 +662,7 @@
           const mx   = t.clientX - rect.left - 2;
           const my   = t.clientY - rect.top  - 2;
           const anchorSq = findClosestSquare(orient, Math.floor(my / SQ), Math.floor(mx / SQ));
-          startDrag(p.id, anchorSq[0], anchorSq[1], t.clientX, t.clientY);
+          pendingDrag = { pieceId: p.id, anchorR: anchorSq[0], anchorC: anchorSq[1], startX: t.clientX, startY: t.clientY };
         }, { passive: false });
       }
 
@@ -600,11 +672,13 @@
       rotBtn.title       = 'Rotate (→ or R key when piece is selected)';
       rotBtn.disabled    = isUsed;
       rotBtn.setAttribute('aria-label', `Rotate piece ${p.id + 1}`);
+      // Prevent mousedown bubbling so it never triggers pendingDrag on the canvas
+      rotBtn.addEventListener('mousedown', e => e.stopPropagation());
+      rotBtn.addEventListener('touchstart', e => e.stopPropagation(), { passive: true });
       rotBtn.addEventListener('click', e => {
         e.stopPropagation();
-        if (isUsed || drag.active) return;
+        if (isUsed || drag.active || pendingDrag) return;
         orientIdxs[p.id] = (orientIdxs[p.id] + 1) % PIECE_ORIENTATIONS[p.id].length;
-        // Rebuild ghost if currently dragging this piece
         renderPieceTray();
         renderBoard();
       });
@@ -617,6 +691,7 @@
 
   // ── Click-to-place handler ────────────────────────────────────────────────────
   function handleCellClick(r, c) {
+    if (suppressBoardClick) { suppressBoardClick = false; return; }
     if (mode !== 'play' || drag.active) return;
     const k         = `${r},${c}`;
     const targetRCs = getTargetRCs();
@@ -624,21 +699,15 @@
 
     const placedMap = getPlacedCellMap();
 
-    // Piece selected — place it, displacing any pieces already in the way
+    // Piece selected — place it (overlapping allowed, conflicts shown in red)
     if (selectedPiece !== null) {
-      const orient       = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
-      const placed       = orient.map(([pr, pc]) => ({ r: r + pr, c: c + pc }));
-      const conflictPids = new Set();
-      placed.forEach(({ r: pr, c: pc }) => {
-        const pid = placedMap[`${pr},${pc}`];
-        if (pid !== undefined) conflictPids.add(pid);
-      });
+      const orient = PIECE_ORIENTATIONS[selectedPiece][orientIdxs[selectedPiece]];
+      const placed = orient.map(([pr, pc]) => ({ r: r + pr, c: c + pc }));
       const isValid = placed.every(({ r: pr, c: pc }) => {
         const pk = `${pr},${pc}`;
         return ALL_VALID.has(pk) && !PERM_BLOCKED.has(pk) && !targetRCs.has(pk);
       });
       if (isValid) {
-        conflictPids.forEach(cid => { delete placedPieces[cid]; });
         placedPieces[selectedPiece] = placed;
         selectedPiece = null;
         renderBoard();

--- a/project.html
+++ b/project.html
@@ -508,39 +508,49 @@
             <div class="cal-date-display" id="calDateDisplay"></div>
           </div>
 
-          <!-- Board -->
-          <div class="cal-board" id="calBoard" role="grid" aria-label="Calendar puzzle board"></div>
+          <!-- Game area: piece tray on left, board on right -->
+          <div class="cal-game-layout">
 
-          <!-- Win banner -->
-          <div class="cal-win-banner" id="calWinBanner" hidden>&#x1F389; Puzzle Solved!</div>
-
-          <!-- No solutions message -->
-          <div class="cal-no-solutions" id="calNoSolutions" hidden>No solutions found for this combination.</div>
-
-          <!-- Controls -->
-          <div class="cal-controls">
-            <button class="btn btn-outline" id="calSolve">&#128269; Show Solutions</button>
-            <button class="btn btn-outline" id="calReset">&#8635; Reset</button>
-          </div>
-
-          <!-- Piece tray (play mode) -->
-          <div class="cal-piece-tray" id="calPieceTray">
-            <p class="cal-piece-tray-label">Drag a piece onto the board &middot; or click to select, then click the board to place &middot; drag or click placed pieces to move them</p>
-            <div class="cal-pieces-grid" id="calPiecesGrid"></div>
-          </div>
-
-          <!-- Solution Panel (shown only when solutions are found) -->
-          <div class="cal-solution-panel" id="calSolutionPanel" hidden>
-            <div class="cal-solution-panel-header">
-              <span class="cal-solution-panel-title">Solution Viewer</span>
-              <button class="cal-solution-back-btn" id="calBackToPlay">&#8592; Back to Playing</button>
+            <!-- Piece tray (play mode) — left panel -->
+            <div class="cal-piece-tray" id="calPieceTray">
+              <p class="cal-piece-tray-label">Pieces</p>
+              <div class="cal-pieces-grid" id="calPiecesGrid"></div>
             </div>
-            <div class="cal-solution-panel-nav">
-              <button class="cal-sol-arrow" id="calPrevSol" aria-label="Previous solution">&#8249;</button>
-              <span class="cal-sol-count" id="calSolCount">Solution 1 of 5</span>
-              <button class="cal-sol-arrow" id="calNextSol" aria-label="Next solution">&#8250;</button>
-            </div>
-          </div>
+
+            <!-- Board column -->
+            <div class="cal-board-column">
+
+              <!-- Board -->
+              <div class="cal-board" id="calBoard" role="grid" aria-label="Calendar puzzle board"></div>
+
+              <!-- Win banner -->
+              <div class="cal-win-banner" id="calWinBanner" hidden>&#x1F389; Puzzle Solved!</div>
+
+              <!-- No solutions message -->
+              <div class="cal-no-solutions" id="calNoSolutions" hidden>No solutions found for this combination.</div>
+
+              <!-- Controls -->
+              <div class="cal-controls">
+                <button class="btn btn-outline" id="calSolve">&#128269; Show Solutions</button>
+                <button class="btn btn-outline" id="calReset">&#8635; Reset</button>
+              </div>
+
+              <!-- Solution Panel (shown only when solutions are found) -->
+              <div class="cal-solution-panel" id="calSolutionPanel" hidden>
+                <div class="cal-solution-panel-header">
+                  <span class="cal-solution-panel-title">Solution Viewer</span>
+                  <button class="cal-solution-back-btn" id="calBackToPlay">&#8592; Back to Playing</button>
+                </div>
+                <div class="cal-solution-panel-nav">
+                  <button class="cal-sol-arrow" id="calPrevSol" aria-label="Previous solution">&#8249;</button>
+                  <span class="cal-sol-count" id="calSolCount">Solution 1 of 5</span>
+                  <button class="cal-sol-arrow" id="calNextSol" aria-label="Next solution">&#8250;</button>
+                </div>
+              </div>
+
+            </div><!-- /.cal-board-column -->
+
+          </div><!-- /.cal-game-layout -->
 
         </div>
       </div>

--- a/project.html
+++ b/project.html
@@ -286,8 +286,80 @@
       </div>
     </section>
 
+    <!-- ── Calendar Puzzle ── -->
+    <section class="section" id="calendar-puzzle" aria-label="Calendar Puzzle">
+      <div class="container">
+        <div class="section-header">
+          <p class="section-label">Personal Project</p>
+          <h2 class="section-title">Calendar Puzzle</h2>
+          <div class="section-divider"></div>
+        </div>
+
+        <div class="projects-section-intro">
+          <p>
+            A daily puzzle: cover every cell on the board except today's month, day, and weekday using ten uniquely shaped pieces. Each date has multiple solutions &mdash; find one yourself or let the solver reveal them.
+          </p>
+        </div>
+
+        <div class="calendar-puzzle-wrapper">
+
+          <!-- Date picker -->
+          <div class="cal-date-picker-wrap">
+            <label class="cal-date-label" for="calDateInput">Date</label>
+            <input type="date" id="calDateInput" class="cal-date-input">
+            <div class="cal-date-display" id="calDateDisplay"></div>
+          </div>
+
+          <!-- Game area: piece tray on left, board on right -->
+          <div class="cal-game-layout">
+
+            <!-- Piece tray (play mode) — left panel -->
+            <div class="cal-piece-tray" id="calPieceTray">
+              <p class="cal-piece-tray-label">Pieces</p>
+              <div class="cal-pieces-grid" id="calPiecesGrid"></div>
+            </div>
+
+            <!-- Board column -->
+            <div class="cal-board-column">
+
+              <!-- Board -->
+              <div class="cal-board" id="calBoard" role="grid" aria-label="Calendar puzzle board"></div>
+
+              <!-- Win banner -->
+              <div class="cal-win-banner" id="calWinBanner" hidden>&#x1F389; Puzzle Solved!</div>
+
+              <!-- No solutions message -->
+              <div class="cal-no-solutions" id="calNoSolutions" hidden>No solutions found for this combination.</div>
+
+              <!-- Controls -->
+              <div class="cal-controls">
+                <button class="btn btn-outline" id="calSolve">&#128269; Show Solutions</button>
+                <button class="btn btn-outline" id="calReset">&#8635; Reset</button>
+              </div>
+
+              <!-- Solution Panel (shown only when solutions are found) -->
+              <div class="cal-solution-panel" id="calSolutionPanel" hidden>
+                <div class="cal-solution-panel-header">
+                  <span class="cal-solution-panel-title">Solution Viewer</span>
+                  <button class="cal-solution-back-btn" id="calBackToPlay">&#8592; Back to Playing</button>
+                </div>
+                <div class="cal-solution-panel-nav">
+                  <button class="cal-sol-arrow" id="calPrevSol" aria-label="Previous solution">&#8249;</button>
+                  <span class="cal-sol-count" id="calSolCount">Solution 1 of 5</span>
+                  <button class="cal-sol-arrow" id="calNextSol" aria-label="Next solution">&#8250;</button>
+                </div>
+              </div>
+
+            </div><!-- /.cal-board-column -->
+
+          </div><!-- /.cal-game-layout -->
+
+        </div>
+      </div>
+    </section>
+
     <!-- ── Senior Project: AI Games ── -->
-    <section class="section" id="games" aria-label="AI Game Suite">
+    <section class="section section-alt" id="games" aria-label="AI Game Suite">
       <div class="container">
         <div class="section-header">
           <p class="section-label">Senior Project &mdash; Indiana Tech</p>
@@ -484,77 +556,6 @@
       </div>
     </section>
 
-    <!-- ── Calendar Puzzle ── -->
-    <section class="section" id="calendar-puzzle" aria-label="Calendar Puzzle">
-      <div class="container">
-        <div class="section-header">
-          <p class="section-label">Personal Project</p>
-          <h2 class="section-title">Calendar Puzzle</h2>
-          <div class="section-divider"></div>
-        </div>
-
-        <div class="projects-section-intro">
-          <p>
-            A daily puzzle: cover every cell on the board except today's month, day, and weekday using ten uniquely shaped pieces. Each date has multiple solutions &mdash; find one yourself or let the solver reveal them.
-          </p>
-        </div>
-
-        <div class="calendar-puzzle-wrapper">
-
-          <!-- Date picker -->
-          <div class="cal-date-picker-wrap">
-            <label class="cal-date-label" for="calDateInput">Date</label>
-            <input type="date" id="calDateInput" class="cal-date-input">
-            <div class="cal-date-display" id="calDateDisplay"></div>
-          </div>
-
-          <!-- Game area: piece tray on left, board on right -->
-          <div class="cal-game-layout">
-
-            <!-- Piece tray (play mode) — left panel -->
-            <div class="cal-piece-tray" id="calPieceTray">
-              <p class="cal-piece-tray-label">Pieces</p>
-              <div class="cal-pieces-grid" id="calPiecesGrid"></div>
-            </div>
-
-            <!-- Board column -->
-            <div class="cal-board-column">
-
-              <!-- Board -->
-              <div class="cal-board" id="calBoard" role="grid" aria-label="Calendar puzzle board"></div>
-
-              <!-- Win banner -->
-              <div class="cal-win-banner" id="calWinBanner" hidden>&#x1F389; Puzzle Solved!</div>
-
-              <!-- No solutions message -->
-              <div class="cal-no-solutions" id="calNoSolutions" hidden>No solutions found for this combination.</div>
-
-              <!-- Controls -->
-              <div class="cal-controls">
-                <button class="btn btn-outline" id="calSolve">&#128269; Show Solutions</button>
-                <button class="btn btn-outline" id="calReset">&#8635; Reset</button>
-              </div>
-
-              <!-- Solution Panel (shown only when solutions are found) -->
-              <div class="cal-solution-panel" id="calSolutionPanel" hidden>
-                <div class="cal-solution-panel-header">
-                  <span class="cal-solution-panel-title">Solution Viewer</span>
-                  <button class="cal-solution-back-btn" id="calBackToPlay">&#8592; Back to Playing</button>
-                </div>
-                <div class="cal-solution-panel-nav">
-                  <button class="cal-sol-arrow" id="calPrevSol" aria-label="Previous solution">&#8249;</button>
-                  <span class="cal-sol-count" id="calSolCount">Solution 1 of 5</span>
-                  <button class="cal-sol-arrow" id="calNextSol" aria-label="Next solution">&#8250;</button>
-                </div>
-              </div>
-
-            </div><!-- /.cal-board-column -->
-
-          </div><!-- /.cal-game-layout -->
-
-        </div>
-      </div>
-    </section>
 
   </main>
 


### PR DESCRIPTION
## Summary

- **Faster solutions**: Worker now streams each solution as it's found — the first result appears almost instantly instead of waiting for all 100 to load
- **Click vs drag threshold**: Clicking a piece now selects it (5px movement required before drag starts), fixing the "immediately dragging on click" issue
- **Rotation buttons fixed**: Rotate button `mousedown` stops propagation so it no longer accidentally triggers a drag
- **Overlapping pieces**: Pieces can now be dropped on top of each other — overlapping cells turn red so the user can see and resolve conflicts; win state requires zero conflicts
- **Layout**: Piece tray moved to the left of the board on desktop (140px side panel); stacks below board on mobile/tablet (≤ 700px) so dragging onto the board feels seamless
- **Controls moved**: Show Solutions / Reset buttons now live below the board, not in the drag path

## Test plan

- [ ] Click a tray piece — it should highlight (select), not immediately start dragging
- [ ] Drag a tray piece with clear movement — ghost appears and follows cursor onto board
- [ ] Click the rotate button — piece rotates without triggering a drag
- [ ] Drop one piece on top of another — overlap cells turn red; moving either piece resolves red
- [ ] Click Show Solutions — first solution appears within ~1 second; counter updates as more are found
- [ ] On mobile (≤ 700px) — piece tray appears below the board
- [ ] On desktop — piece tray appears to the left of the board

https://claude.ai/code/session_01APTFgr1Ens2otvuYae6zau

---
_Generated by [Claude Code](https://claude.ai/code/session_01APTFgr1Ens2otvuYae6zau)_