### PR TITLE
Add fortwaynebusinesses.com as a side project

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1260,6 +1260,18 @@ ul {
   content: '↑';
 }
 
+.project-card-link {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--blue);
+  text-decoration: none;
+  align-self: flex-start;
+}
+
+.project-card-link:hover {
+  text-decoration: underline;
+}
+
 .tech-tags {
   display: flex;
   gap: 5px;

--- a/css/main.css
+++ b/css/main.css
@@ -1260,6 +1260,11 @@ ul {
   content: '↑';
 }
 
+.project-cards-grid--single {
+  grid-template-columns: minmax(0, 560px);
+  justify-content: center;
+}
+
 .project-card-link {
   font-size: 0.82rem;
   font-weight: 600;

--- a/project.html
+++ b/project.html
@@ -557,6 +557,44 @@
     </section>
 
 
+    <!-- ── Fort Wayne Businesses ── -->
+    <section class="section" id="fwb" aria-label="Fort Wayne Businesses">
+      <div class="container">
+        <div class="section-header">
+          <p class="section-label">Side Project</p>
+          <h2 class="section-title">Fort Wayne Businesses</h2>
+          <div class="section-divider"></div>
+        </div>
+
+        <div class="projects-section-intro">
+          <p>
+            A local resource for discovering businesses across Fort Wayne, IN &mdash; built and launched as a side project to support the community I live and work in.
+          </p>
+        </div>
+
+        <div class="project-cards-grid">
+
+          <div class="project-card">
+            <div class="project-card-header">
+              <div class="project-card-icon">FW</div>
+              <div class="project-card-title-wrap">
+                <h3 class="project-card-title">fortwaynebusinesses.com</h3>
+                <div class="tech-tags">
+                  <span class="tech-tag">Web</span>
+                </div>
+              </div>
+            </div>
+            <p class="project-card-desc">
+              A directory connecting people with local businesses in Fort Wayne. Built to make it easier to find and support what the city has to offer — from restaurants and services to shops and professionals.
+            </p>
+            <a class="project-card-link" href="https://fortwaynebusinesses.com" target="_blank" rel="noopener">Visit fortwaynebusinesses.com &rarr;</a>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+
   </main>
 
   <!-- @@footer:start -->

--- a/project.html
+++ b/project.html
@@ -286,8 +286,45 @@
       </div>
     </section>
 
+    <!-- ── Fort Wayne Businesses ── -->
+    <section class="section" id="fwb" aria-label="Fort Wayne Businesses">
+      <div class="container">
+        <div class="section-header">
+          <p class="section-label">Side Project</p>
+          <h2 class="section-title">Fort Wayne Businesses</h2>
+          <div class="section-divider"></div>
+        </div>
+
+        <div class="projects-section-intro">
+          <p>
+            A local resource for discovering businesses across Fort Wayne, IN &mdash; built and launched as a side project to support the community I live and work in.
+          </p>
+        </div>
+
+        <div class="project-cards-grid project-cards-grid--single">
+
+          <div class="project-card">
+            <div class="project-card-header">
+              <div class="project-card-icon">FW</div>
+              <div class="project-card-title-wrap">
+                <h3 class="project-card-title">fortwaynebusinesses.com</h3>
+                <div class="tech-tags">
+                  <span class="tech-tag">Web</span>
+                </div>
+              </div>
+            </div>
+            <p class="project-card-desc">
+              A directory connecting people with local businesses in Fort Wayne. Built to make it easier to find and support what the city has to offer — from restaurants and services to shops and professionals.
+            </p>
+            <a class="project-card-link" href="https://fortwaynebusinesses.com" target="_blank" rel="noopener">Visit fortwaynebusinesses.com &rarr;</a>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
     <!-- ── Calendar Puzzle ── -->
-    <section class="section" id="calendar-puzzle" aria-label="Calendar Puzzle">
+    <section class="section section-alt" id="calendar-puzzle" aria-label="Calendar Puzzle">
       <div class="container">
         <div class="section-header">
           <p class="section-label">Personal Project</p>
@@ -359,7 +396,7 @@
     </section>
 
     <!-- ── Senior Project: AI Games ── -->
-    <section class="section section-alt" id="games" aria-label="AI Game Suite">
+    <section class="section" id="games" aria-label="AI Game Suite">
       <div class="container">
         <div class="section-header">
           <p class="section-label">Senior Project &mdash; Indiana Tech</p>
@@ -556,43 +593,6 @@
       </div>
     </section>
 
-
-    <!-- ── Fort Wayne Businesses ── -->
-    <section class="section" id="fwb" aria-label="Fort Wayne Businesses">
-      <div class="container">
-        <div class="section-header">
-          <p class="section-label">Side Project</p>
-          <h2 class="section-title">Fort Wayne Businesses</h2>
-          <div class="section-divider"></div>
-        </div>
-
-        <div class="projects-section-intro">
-          <p>
-            A local resource for discovering businesses across Fort Wayne, IN &mdash; built and launched as a side project to support the community I live and work in.
-          </p>
-        </div>
-
-        <div class="project-cards-grid">
-
-          <div class="project-card">
-            <div class="project-card-header">
-              <div class="project-card-icon">FW</div>
-              <div class="project-card-title-wrap">
-                <h3 class="project-card-title">fortwaynebusinesses.com</h3>
-                <div class="tech-tags">
-                  <span class="tech-tag">Web</span>
-                </div>
-              </div>
-            </div>
-            <p class="project-card-desc">
-              A directory connecting people with local businesses in Fort Wayne. Built to make it easier to find and support what the city has to offer — from restaurants and services to shops and professionals.
-            </p>
-            <a class="project-card-link" href="https://fortwaynebusinesses.com" target="_blank" rel="noopener">Visit fortwaynebusinesses.com &rarr;</a>
-          </div>
-
-        </div>
-      </div>
-    </section>
 
 
   </main>

--- a/resume.html
+++ b/resume.html
@@ -483,6 +483,7 @@
             <li><strong>Call Queue Dashboard Suite (Grafana):</strong> Four dashboards providing real-time and historical visibility into call queue volume, engineer performance, and missed-call patterns</li>
             <li><strong>AI Game Suite (JavaScript):</strong> Tic-Tac-Toe and Connect Four with fully implemented MinMax and Alpha-Beta Pruning algorithms; built as senior capstone project at Indiana Tech</li>
             <li><strong>Backup System Monitor (Grafana):</strong> Surfaces failed backup jobs across all managed client devices at a glance, replacing daily manual checks</li>
+            <li><strong>Fort Wayne Businesses (<a href="https://fortwaynebusinesses.com" target="_blank" rel="noopener">fortwaynebusinesses.com</a>):</strong> Launched a local business directory for Fort Wayne, IN as a community side project</li>
           </ul>
         </section>
 


### PR DESCRIPTION
## Summary

- Adds a new **Fort Wayne Businesses** section to the Projects page (`project.html`) with a card and live link to fortwaynebusinesses.com
- Adds fortwaynebusinesses.com as a bullet under **Notable Projects** on the Resume page (`resume.html`)
- Adds a `project-card-link` CSS class for the live site link styling

## Why Projects + Resume (not About)

The About page is personal background — values, experience, community involvement. The Projects page is the right home for a launched website, and the Resume's Notable Projects section makes sense since it's a shipped product worth highlighting professionally. The About page wasn't a fit.

https://claude.ai/code/session_014gJ5RZ6nKYY1XJEDXPcvL7

---
_Generated by [Claude Code](https://claude.ai/code/session_014gJ5RZ6nKYY1XJEDXPcvL7)_