### PR TITLE
Add resume download button linking to Dexter_Miller_Resume.docx

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -96,6 +96,7 @@
     .top-bar a:hover { color: #ffffff; }
 
     .print-btn {
+      display: inline-block;
       background: var(--blue);
       color: #ffffff;
       border: none;
@@ -105,6 +106,7 @@
       font-size: 0.82rem;
       font-weight: 600;
       cursor: pointer;
+      text-decoration: none;
       transition: background 0.2s;
     }
 
@@ -390,7 +392,7 @@
     <span>
       <a href="index.html">&larr; Back to dextermiller.com</a>
     </span>
-    <button class="print-btn" onclick="window.print()">&#8595; Download Resume</button>
+    <a class="print-btn" href="files/Dexter_Miller_Resume.docx" download="Dexter_Miller_Resume.docx">&#8595; Download Resume</a>
   </div>
 
   <div class="resume">


### PR DESCRIPTION
## Summary
- Changed the "Download Resume" button in `resume.html` from triggering `window.print()` to directly downloading `files/Dexter_Miller_Resume.docx`
- Converted the `<button>` to an `<a>` element with `download` attribute
- Added `display: inline-block` and `text-decoration: none` to `.print-btn` styles so the link renders identically to the old button

## Test plan
- [ ] Visit `/resume.html`
- [ ] Click "Download Resume" — browser should download `Dexter_Miller_Resume.docx`
- [ ] Verify button appearance is unchanged

https://claude.ai/code/session_014n8h24mXW7Bb6ruiy9LRdu

---
_Generated by [Claude Code](https://claude.ai/code/session_014n8h24mXW7Bb6ruiy9LRdu)_