### PR TITLE
Replace DM initials with logo images in nav

### DIFF
--- a/404.html
+++ b/404.html
@@ -102,7 +102,10 @@
   <!-- ── Navigation ── -->
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
-      <a class="nav-logo" href="index.html">DM</a>
+      <a class="nav-logo" href="index.html">
+        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+      </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
         <span></span>

--- a/contact.html
+++ b/contact.html
@@ -241,7 +241,10 @@
   <!-- ── Navigation ── -->
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
-      <a class="nav-logo" href="index.html">DM</a>
+      <a class="nav-logo" href="index.html">
+        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+      </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
         <span></span>

--- a/css/main.css
+++ b/css/main.css
@@ -176,17 +176,26 @@ ul {
 }
 
 .nav-logo {
-  font-family: var(--font-head);
-  font-weight: 700;
-  font-size: 1.2rem;
-  color: #ffffff;
-  letter-spacing: 0.06em;
+  display: flex;
+  align-items: center;
   padding: 8px 4px;
 }
 
-.nav-logo:hover {
-  color: var(--blue-pale);
+.nav-logo-img {
+  height: 36px;
+  width: auto;
+  transition: opacity var(--transition);
 }
+
+.nav-logo:hover .nav-logo-img {
+  opacity: 0.8;
+}
+
+/* Show light logo by default, dark logo in dark mode */
+.nav-logo-dark { display: none; }
+.nav-logo-light { display: block; }
+[data-theme="dark"] .nav-logo-dark { display: block; }
+[data-theme="dark"] .nav-logo-light { display: none; }
 
 .nav-links {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -115,7 +115,10 @@
   <!-- ── Navigation ── -->
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
-      <a class="nav-logo" href="index.html">DM</a>
+      <a class="nav-logo" href="index.html">
+        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+      </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
         <span></span>

--- a/project.html
+++ b/project.html
@@ -109,7 +109,10 @@
   <!-- ── Navigation ── -->
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
-      <a class="nav-logo" href="index.html">DM</a>
+      <a class="nav-logo" href="index.html">
+        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+      </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
         <span></span>

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -1,7 +1,10 @@
   <!-- ── Navigation ── -->
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
-      <a class="nav-logo" href="index.html">DM</a>
+      <a class="nav-logo" href="index.html">
+        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+      </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
         <span></span>


### PR DESCRIPTION
## Summary

- Replaces the "DM" text logo in the top-left nav with `logo-light.png` and `logo-dark.png`
- Light logo shown by default; dark logo shown when `[data-theme="dark"]` is set
- Logo sized to 36px height with smooth opacity hover effect
- Nav partial updated and rebuilt into all 4 HTML pages via `build.js`

## Test plan

- [ ] Visit site in light mode — `logo-light.png` appears in top-left nav
- [ ] Toggle dark mode — logo switches to `logo-dark.png`
- [ ] Hover over logo — subtle opacity fade visible
- [ ] Check all pages (index, project, contact, 404) show the logo correctly
- [ ] Verify logo links back to `index.html`

https://claude.ai/code/session_01Vh9TEzYMZqAFxFwqqW1sdU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh9TEzYMZqAFxFwqqW1sdU)_