### PR TITLE
Use light logo only in nav and replace LinkedIn link with Blog

### DIFF
--- a/404.html
+++ b/404.html
@@ -103,8 +103,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
-        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
@@ -115,7 +114,7 @@
         <a class="nav-link" href="index.html">About</a>
         <a class="nav-link" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://www.linkedin.com/in/dextermiller2020" target="_blank" rel="noopener">LinkedIn</a>
+        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
         <a class="nav-link" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/contact.html
+++ b/contact.html
@@ -242,8 +242,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
-        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
@@ -254,7 +253,7 @@
         <a class="nav-link" href="index.html">About</a>
         <a class="nav-link" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://www.linkedin.com/in/dextermiller2020" target="_blank" rel="noopener">LinkedIn</a>
+        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
         <a class="nav-link active" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/css/main.css
+++ b/css/main.css
@@ -191,11 +191,6 @@ ul {
   opacity: 0.8;
 }
 
-/* Show light logo by default, dark logo in dark mode */
-.nav-logo-dark { display: none; }
-.nav-logo-light { display: block; }
-[data-theme="dark"] .nav-logo-dark { display: block; }
-[data-theme="dark"] .nav-logo-light { display: none; }
 
 .nav-links {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -116,8 +116,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
-        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
@@ -128,7 +127,7 @@
         <a class="nav-link active" href="index.html">About</a>
         <a class="nav-link" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://www.linkedin.com/in/dextermiller2020" target="_blank" rel="noopener">LinkedIn</a>
+        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
         <a class="nav-link" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/project.html
+++ b/project.html
@@ -110,8 +110,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
-        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
@@ -122,7 +121,7 @@
         <a class="nav-link" href="index.html">About</a>
         <a class="nav-link active" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://www.linkedin.com/in/dextermiller2020" target="_blank" rel="noopener">LinkedIn</a>
+        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
         <a class="nav-link" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -2,8 +2,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img nav-logo-light" src="images/logo-light.png" alt="Dexter Miller">
-        <img class="nav-logo-img nav-logo-dark" src="images/logo-dark.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>
@@ -14,7 +13,7 @@
         <a class="nav-link{{ACTIVE_ABOUT}}" href="index.html">About</a>
         <a class="nav-link{{ACTIVE_PROJECTS}}" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://www.linkedin.com/in/dextermiller2020" target="_blank" rel="noopener">LinkedIn</a>
+        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
         <a class="nav-link{{ACTIVE_CONTACT}}" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Always show `logo-light.png` in the nav header — the dark logo was hard to see against the always-dark nav background
- Removed the CSS rules that swapped between light/dark logos based on theme (`data-theme="dark"`)
- Replaced the LinkedIn nav link with a Blog link pointing to `blog.dextermiller.com`

## Test plan

- [ ] Verify the light logo appears in both light and dark mode
- [ ] Verify the "Blog" nav link appears and opens `blog.dextermiller.com` in a new tab
- [ ] Confirm LinkedIn link is gone from all pages (index, project, contact, 404)

https://claude.ai/code/session_016Kk76QkD7rS6vtFgsFKomW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kk76QkD7rS6vtFgsFKomW)_