### PR TITLE
Switch nav logo from light to dark variant

### DIFF
--- a/404.html
+++ b/404.html
@@ -103,7 +103,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-dark.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>

--- a/contact.html
+++ b/contact.html
@@ -242,7 +242,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-dark.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-dark.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>

--- a/project.html
+++ b/project.html
@@ -110,7 +110,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-dark.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -2,7 +2,7 @@
   <nav class="site-nav" aria-label="Main navigation">
     <div class="nav-container">
       <a class="nav-logo" href="index.html">
-        <img class="nav-logo-img" src="images/logo-light.png" alt="Dexter Miller">
+        <img class="nav-logo-img" src="images/logo-dark.png" alt="Dexter Miller">
       </a>
       <button class="nav-hamburger" id="navHamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">
         <span></span>


### PR DESCRIPTION
Swaps `logo-light.png` for `logo-dark.png` in the nav header across all pages.

https://claude.ai/code/session_016Kk76QkD7rS6vtFgsFKomW

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kk76QkD7rS6vtFgsFKomW)_