### PR TITLE
Open Blog nav link in same tab instead of new tab

### DIFF
--- a/404.html
+++ b/404.html
@@ -114,7 +114,7 @@
         <a class="nav-link" href="index.html">About</a>
         <a class="nav-link" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
+        <a class="nav-link" href="https://blog.dextermiller.com">Blog</a>
         <a class="nav-link" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/contact.html
+++ b/contact.html
@@ -253,7 +253,7 @@
         <a class="nav-link" href="index.html">About</a>
         <a class="nav-link" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
+        <a class="nav-link" href="https://blog.dextermiller.com">Blog</a>
         <a class="nav-link active" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
         <a class="nav-link active" href="index.html">About</a>
         <a class="nav-link" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
+        <a class="nav-link" href="https://blog.dextermiller.com">Blog</a>
         <a class="nav-link" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/project.html
+++ b/project.html
@@ -121,7 +121,7 @@
         <a class="nav-link" href="index.html">About</a>
         <a class="nav-link active" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
+        <a class="nav-link" href="https://blog.dextermiller.com">Blog</a>
         <a class="nav-link" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -13,7 +13,7 @@
         <a class="nav-link{{ACTIVE_ABOUT}}" href="index.html">About</a>
         <a class="nav-link{{ACTIVE_PROJECTS}}" href="project.html">Projects</a>
         <a class="nav-link" href="resume.html" target="_blank" rel="noopener">Resume</a>
-        <a class="nav-link" href="https://blog.dextermiller.com" target="_blank" rel="noopener">Blog</a>
+        <a class="nav-link" href="https://blog.dextermiller.com">Blog</a>
         <a class="nav-link{{ACTIVE_CONTACT}}" href="contact.html">Contact</a>
         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Toggle dark mode">
           <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>


### PR DESCRIPTION
Removes `target="_blank" rel="noopener"` from the Blog nav link so clicking it redirects the current tab to `blog.dextermiller.com` instead of opening a new one.

https://claude.ai/code/session_016Kk76QkD7rS6vtFgsFKomW

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kk76QkD7rS6vtFgsFKomW)_